### PR TITLE
Adding support of feeding some camera diagnostics to the diagnostic a…

### DIFF
--- a/spinnaker_camera_driver/CMakeLists.txt
+++ b/spinnaker_camera_driver/CMakeLists.txt
@@ -77,8 +77,12 @@ add_library(Cm3 src/cm3.cpp)
 target_link_libraries(Cm3 Camera ${catkin_LIBRARIES})
 add_dependencies(Cm3 ${PROJECT_NAME}_gencfg)
 
+add_library(Diagnostics src/diagnostics.cpp)
+target_link_libraries(Diagnostics Camera SpinnakerCameraLib ${catkin_LIBRARIES})
+add_dependencies(Diagnostics ${PROJECT_NAME}_gencfg)
+
 add_library(SpinnakerCameraNodelet src/nodelet.cpp)
-target_link_libraries(SpinnakerCameraNodelet SpinnakerCameraLib Camera Cm3 ${catkin_LIBRARIES})
+target_link_libraries(SpinnakerCameraNodelet Diagnostics SpinnakerCameraLib Camera Cm3 ${catkin_LIBRARIES})
 
 add_executable(spinnaker_camera_node src/node.cpp)
 target_link_libraries(spinnaker_camera_node SpinnakerCameraLib ${catkin_LIBRARIES})
@@ -88,6 +92,7 @@ install(TARGETS
   SpinnakerCameraLib
   SpinnakerCameraNodelet
   Camera
+  Diagnostics
   spinnaker_camera_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/spinnaker_camera_driver/include/spinnaker_camera_driver/SpinnakerCamera.h
+++ b/spinnaker_camera_driver/include/spinnaker_camera_driver/SpinnakerCamera.h
@@ -162,6 +162,8 @@ public:
   int getHeightMax();
   int getWidthMax();
 
+ Spinnaker::GenApi::CNodePtr
+  readProperty(const Spinnaker::GenICam::gcstring property_name);
   uint32_t getSerial()
   {
     return serial_;

--- a/spinnaker_camera_driver/include/spinnaker_camera_driver/SpinnakerCamera.h
+++ b/spinnaker_camera_driver/include/spinnaker_camera_driver/SpinnakerCamera.h
@@ -161,9 +161,8 @@ public:
   void setGain(const float& gain);
   int getHeightMax();
   int getWidthMax();
+  Spinnaker::GenApi::CNodePtr readProperty(const Spinnaker::GenICam::gcstring property_name);
 
- Spinnaker::GenApi::CNodePtr
-  readProperty(const Spinnaker::GenICam::gcstring property_name);
   uint32_t getSerial()
   {
     return serial_;

--- a/spinnaker_camera_driver/include/spinnaker_camera_driver/camera.h
+++ b/spinnaker_camera_driver/include/spinnaker_camera_driver/camera.h
@@ -66,6 +66,9 @@ public:
   int getHeightMax();
   int getWidthMax();
 
+  Spinnaker::GenApi::CNodePtr
+  readProperty(const Spinnaker::GenICam::gcstring property_name);
+
 protected:
   Spinnaker::GenApi::INodeMap* node_map_;
 

--- a/spinnaker_camera_driver/include/spinnaker_camera_driver/diagnostics.h
+++ b/spinnaker_camera_driver/include/spinnaker_camera_driver/diagnostics.h
@@ -1,0 +1,142 @@
+/**
+Software License Agreement (BSD)
+
+\file      diagnostics.cpp
+\authors   Michael Lowe <michael@ascent.ai>
+\copyright Copyright (c) 2018, Ascent Robotics, Inc., All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of Clearpath Robotics nor the names of its contributors may
+   be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*-*-C++-*-*/
+/**
+   @file diagnostics.h
+   @author Michael Lowe
+   @date August 1, 2018
+   @brief Class to support ROS Diagnostics Aggregator for Spinnaker Camera
+
+   @attention Copyright (C) 2018
+*/
+
+#ifndef INCLUDE_DIAGNOSTICS_MANAGER_
+#define INCLUDE_DIAGNOSTICS_MANAGER_
+
+#include "spinnaker_camera_driver/SpinnakerCamera.h"
+#include "spinnaker_camera_driver/diagnostics.h"
+#include <diagnostic_msgs/DiagnosticArray.h>
+#include <diagnostic_msgs/DiagnosticStatus.h>
+#include <ros/ros.h>
+#include <spinnaker/Spinnaker.h>
+
+namespace spinnaker_camera_driver {
+class DiagnosticsManager {
+
+public:
+  DiagnosticsManager(const std::string name, const std::string serial,
+                     std::shared_ptr<ros::Publisher> const &pub);
+  ~DiagnosticsManager();
+
+  /*!
+   * \brief Read the property of given parameters and push to aggregator
+   *
+   * Take all the collected parameters that were added read the values, then
+   * publish them to the
+   * allow the diagnostics aggreagtor to collect them
+   * \param spinnaker the SpinnakerCamera object used for getting the parameters
+   * from the spinnaker API
+   */
+  void processDiagnostics(SpinnakerCamera &spinnaker);
+
+  /*!
+   * \brief Add a diagnostic with name only (no warning checks)
+   *
+   * Allows the user to add an integer or float parameter without having to give
+   * additional information.
+   * User must specify the type they are getting
+   * \param name is the name of the parameter as writting in the User Manual
+   */
+  template <typename T> void addDiagnostic(Spinnaker::GenICam::gcstring name);
+
+  /*!
+   * \brief Add a diagnostic with warning checks
+   *
+   * Allows the user to add an integer or float parameter and values to check it
+   * against. Anything outside
+   * of these ranges will be considered an error.
+   * \param name is the name of the parameter as writting in the User Manual
+   */
+  void addDiagnostic(
+      Spinnaker::GenICam::gcstring name, bool check_ranges = false,
+      std::pair<int, int> operational = std::make_pair<int, int>(0, 0),
+      int lower_bound = 0, int upper_bound = 0);
+  void addDiagnostic(
+      Spinnaker::GenICam::gcstring name, bool check_ranges = false,
+      std::pair<float, float> operational = std::make_pair<float, float>(0, 0),
+      float lower_bound = 0, float upper_bound = 0);
+
+private:
+  /*
+   * diagnostic_params is aData Structure to represent a parameter and its
+   * bounds
+   */
+  template <typename T> struct diagnostic_params {
+    Spinnaker::GenICam::gcstring
+        parameter_name; // This should be the same as written in the User Manual
+    bool check_ranges;
+    std::pair<T, T> operational_range; // Normal operatinal range
+    T warn_range_lower;
+    T warn_range_upper;
+  };
+
+  /*!
+   * \brief Function to push the diagnostic to the publisher
+   *
+   * Allows the user to add an integer or float parameter without having to give
+   * additional information.
+   * User must specify the type they are getting
+   * \param diag_array is the array of parameters to be pushed to the publisher
+   * \param param is the diagnostic parameter name and boundaries
+   * \param value is the current value of the parameter requested from the
+   * device
+   */
+  template <typename T>
+  void pushDiagStatus(diagnostic_msgs::DiagnosticArray &diag_array,
+                      const diagnostic_params<T> &param, const T value);
+
+  // constuctor parameters
+  std::string camera_name_;
+  std::string serial_number_;
+  std::shared_ptr<ros::Publisher> diagnostics_pub_;
+
+  // vectors to keep track of the items to publish
+  std::vector<diagnostic_params<int>> integer_params_;
+  std::vector<diagnostic_params<float>> float_params_;
+  // Information about the device model, firmware, etc
+  // TODO: Allow these to be configured
+  const std::vector<std::string> manufacturer_params_{
+      "DeviceVendorName", "DeviceModelName", "SensorDescription",
+      "DeviceFirmwareVersion"};
+};
+}
+
+#endif /* INCLUDE_DIAGNOSTICS_MANAGER_ */

--- a/spinnaker_camera_driver/include/spinnaker_camera_driver/diagnostics.h
+++ b/spinnaker_camera_driver/include/spinnaker_camera_driver/diagnostics.h
@@ -38,8 +38,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    @attention Copyright (C) 2018
 */
 
-#ifndef INCLUDE_DIAGNOSTICS_MANAGER_
-#define INCLUDE_DIAGNOSTICS_MANAGER_
+#ifndef SPINNAKER_CAMERA_DRIVER_DIAGNOSTICS_H
+#define SPINNAKER_CAMERA_DRIVER_DIAGNOSTICS_H
 
 #include "spinnaker_camera_driver/SpinnakerCamera.h"
 #include "spinnaker_camera_driver/diagnostics.h"
@@ -47,12 +47,16 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <diagnostic_msgs/DiagnosticStatus.h>
 #include <ros/ros.h>
 
-namespace spinnaker_camera_driver {
-class DiagnosticsManager {
+#include <utility>
+#include <string>
+#include <vector>
 
+namespace spinnaker_camera_driver
+{
+class DiagnosticsManager
+{
 public:
-  DiagnosticsManager(const std::string name, const std::string serial,
-                     std::shared_ptr<ros::Publisher> const &pub);
+  DiagnosticsManager(const std::string name, const std::string serial, std::shared_ptr<ros::Publisher> const& pub);
   ~DiagnosticsManager();
 
   /*!
@@ -64,7 +68,7 @@ public:
    * \param spinnaker the SpinnakerCamera object used for getting the parameters
    * from the spinnaker API
    */
-  void processDiagnostics(SpinnakerCamera &spinnaker);
+  void processDiagnostics(SpinnakerCamera* spinnaker);
 
   /*!
    * \brief Add a diagnostic with name only (no warning checks)
@@ -74,7 +78,8 @@ public:
    * User must specify the type they are getting
    * \param name is the name of the parameter as writting in the User Manual
    */
-  template <typename T> void addDiagnostic(Spinnaker::GenICam::gcstring name);
+  template <typename T>
+  void addDiagnostic(const Spinnaker::GenICam::gcstring name);
 
   /*!
    * \brief Add a diagnostic with warning checks
@@ -84,25 +89,23 @@ public:
    * of these ranges will be considered an error.
    * \param name is the name of the parameter as writting in the User Manual
    */
-  void addDiagnostic(
-      Spinnaker::GenICam::gcstring name, bool check_ranges = false,
-      std::pair<int, int> operational = std::make_pair<int, int>(0, 0),
-      int lower_bound = 0, int upper_bound = 0);
-  void addDiagnostic(
-      Spinnaker::GenICam::gcstring name, bool check_ranges = false,
-      std::pair<float, float> operational = std::make_pair<float, float>(0, 0),
-      float lower_bound = 0, float upper_bound = 0);
+  void addDiagnostic(const Spinnaker::GenICam::gcstring name, bool check_ranges = false,
+                     std::pair<int, int> operational = std::make_pair(0, 0), int lower_bound = 0, int upper_bound = 0);
+  void addDiagnostic(const Spinnaker::GenICam::gcstring name, bool check_ranges = false,
+                     std::pair<float, float> operational = std::make_pair(0.0, 0.0), float lower_bound = 0,
+                     float upper_bound = 0);
 
 private:
   /*
    * diagnostic_params is aData Structure to represent a parameter and its
    * bounds
    */
-  template <typename T> struct diagnostic_params {
-    Spinnaker::GenICam::gcstring
-        parameter_name; // This should be the same as written in the User Manual
+  template <typename T>
+  struct diagnostic_params
+  {
+    Spinnaker::GenICam::gcstring parameter_name;  // This should be the same as written in the User Manual
     bool check_ranges;
-    std::pair<T, T> operational_range; // Normal operatinal range
+    std::pair<T, T> operational_range;  // Normal operatinal range
     T warn_range_lower;
     T warn_range_upper;
   };
@@ -113,14 +116,12 @@ private:
    * Allows the user to add an integer or float parameter without having to give
    * additional information.
    * User must specify the type they are getting
-   * \param diag_array is the array of parameters to be pushed to the publisher
    * \param param is the diagnostic parameter name and boundaries
    * \param value is the current value of the parameter requested from the
    * device
    */
   template <typename T>
-  void pushDiagStatus(diagnostic_msgs::DiagnosticArray &diag_array,
-                      const diagnostic_params<T> &param, const T value);
+  diagnostic_msgs::DiagnosticStatus getDiagStatus(const diagnostic_params<T>& param, const T value);
 
   // constuctor parameters
   std::string camera_name_;
@@ -131,11 +132,14 @@ private:
   std::vector<diagnostic_params<int>> integer_params_;
   std::vector<diagnostic_params<float>> float_params_;
   // Information about the device model, firmware, etc
-  // TODO: Allow these to be configured
-  const std::vector<std::string> manufacturer_params_{
-      "DeviceVendorName", "DeviceModelName", "SensorDescription",
-      "DeviceFirmwareVersion"};
+  // TODO(mlowe): Allow these to be configured
+  // clang-format off
+  const std::vector<std::string> manufacturer_params_
+  {
+    "DeviceVendorName", "DeviceModelName", "SensorDescription", "DeviceFirmwareVersion"
+  };
+  // clang-format on
 };
-}
+}  // namespace spinnaker_camera_driver
 
-#endif /* INCLUDE_DIAGNOSTICS_MANAGER_ */
+#endif  // SPINNAKER_CAMERA_DRIVER_DIAGNOSTICS_H

--- a/spinnaker_camera_driver/include/spinnaker_camera_driver/diagnostics.h
+++ b/spinnaker_camera_driver/include/spinnaker_camera_driver/diagnostics.h
@@ -46,7 +46,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <diagnostic_msgs/DiagnosticArray.h>
 #include <diagnostic_msgs/DiagnosticStatus.h>
 #include <ros/ros.h>
-#include <spinnaker/Spinnaker.h>
 
 namespace spinnaker_camera_driver {
 class DiagnosticsManager {

--- a/spinnaker_camera_driver/launch/camera.launch
+++ b/spinnaker_camera_driver/launch/camera.launch
@@ -52,5 +52,10 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
     <node pkg="nodelet" type="nodelet" name="image_proc_debayer"
           args="load image_proc/debayer camera_nodelet_manager">
     </node>
+    <node pkg="diagnostic_aggregator" type="aggregator_node"
+        name="diagnostic_aggregator">
+      <rosparam command="load"
+              file="$(find spinnaker_camera_driver)/params/analyzer.yml" />
+    </node>
   </group>
 </launch>

--- a/spinnaker_camera_driver/launch/diagnostics.launch
+++ b/spinnaker_camera_driver/launch/diagnostics.launch
@@ -52,5 +52,10 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
     <node pkg="nodelet" type="nodelet" name="image_proc_debayer"
           args="load image_proc/debayer camera_nodelet_manager">
     </node>
+    <node pkg="diagnostic_aggregator" type="aggregator_node"
+        name="diagnostic_aggregator">
+      <rosparam command="load"
+              file="$(find spinnaker_camera_driver)/params/analyzer.yml" />
+    </node>
   </group>
 </launch>

--- a/spinnaker_camera_driver/params/analyzer.yml
+++ b/spinnaker_camera_driver/params/analyzer.yml
@@ -1,6 +1,6 @@
 pub_rate: 1.0
 analyzers:
     cameras:
-        type: GenericAnalyzer
+        type: diagnostic_aggregator/GenericAnalyzer
         path: Cameras
         startswith: 'Spinnaker'

--- a/spinnaker_camera_driver/params/analyzer.yml
+++ b/spinnaker_camera_driver/params/analyzer.yml
@@ -1,0 +1,6 @@
+pub_rate: 1.0
+analyzers:
+    cameras:
+        type: GenericAnalyzer
+        path: Cameras
+        startswith: 'Spinnaker'

--- a/spinnaker_camera_driver/src/SpinnakerCamera.cpp
+++ b/spinnaker_camera_driver/src/SpinnakerCamera.cpp
@@ -119,6 +119,15 @@ int SpinnakerCamera::getWidthMax()
     return 0;
 }
 
+Spinnaker::GenApi::CNodePtr SpinnakerCamera::readProperty(
+    const Spinnaker::GenICam::gcstring property_name) {
+  if (camera_) {
+    return camera_->readProperty(property_name);
+  } else {
+    return 0;
+  }
+}
+
 void SpinnakerCamera::connect()
 {
   if (!pCam_)

--- a/spinnaker_camera_driver/src/SpinnakerCamera.cpp
+++ b/spinnaker_camera_driver/src/SpinnakerCamera.cpp
@@ -119,11 +119,14 @@ int SpinnakerCamera::getWidthMax()
     return 0;
 }
 
-Spinnaker::GenApi::CNodePtr SpinnakerCamera::readProperty(
-    const Spinnaker::GenICam::gcstring property_name) {
-  if (camera_) {
+Spinnaker::GenApi::CNodePtr SpinnakerCamera::readProperty(const Spinnaker::GenICam::gcstring property_name)
+{
+  if (camera_)
+  {
     return camera_->readProperty(property_name);
-  } else {
+  }
+  else
+  {
     return 0;
   }
 }

--- a/spinnaker_camera_driver/src/camera.cpp
+++ b/spinnaker_camera_driver/src/camera.cpp
@@ -149,12 +149,12 @@ void Camera::setNewConfiguration(const SpinnakerConfig& config, const uint32_t& 
     {
       setProperty(node_map_, "BalanceWhiteAuto", config.auto_white_balance);
       if (config.auto_white_balance.compare(std::string("Off")) == 0)
-      {
-        setProperty(node_map_, "BalanceRatioSelector", "Blue");
-        setProperty(node_map_, "BalanceRatio", static_cast<float>(config.white_balance_blue_ratio));
-        setProperty(node_map_, "BalanceRatioSelector", "Red");
-        setProperty(node_map_, "BalanceRatio", static_cast<float>(config.white_balance_red_ratio));
-      }
+        {
+          setProperty(node_map_, "BalanceRatioSelector", "Blue");
+          setProperty(node_map_, "BalanceRatio", static_cast<float>(config.white_balance_blue_ratio));
+          setProperty(node_map_, "BalanceRatioSelector", "Red");
+          setProperty(node_map_, "BalanceRatio", static_cast<float>(config.white_balance_red_ratio));
+        }
     }
   }
   catch (const Spinnaker::Exception& e)
@@ -284,11 +284,11 @@ int Camera::getWidthMax()
 // float Camera::getCameraFrameRate()
 //{
 //}
-Spinnaker::GenApi::CNodePtr
-Camera::readProperty(const Spinnaker::GenICam::gcstring property_name) {
+Spinnaker::GenApi::CNodePtr Camera::readProperty(const Spinnaker::GenICam::gcstring property_name)
+{
   Spinnaker::GenApi::CNodePtr ptr = node_map_->GetNode(property_name);
-  if (!Spinnaker::GenApi::IsAvailable(ptr) ||
-      !Spinnaker::GenApi::IsReadable(ptr)) {
+  if (!Spinnaker::GenApi::IsAvailable(ptr) || !Spinnaker::GenApi::IsReadable(ptr))
+  {
     throw std::runtime_error("Unable to get parmeter " + property_name);
   }
   return ptr;

--- a/spinnaker_camera_driver/src/camera.cpp
+++ b/spinnaker_camera_driver/src/camera.cpp
@@ -284,6 +284,15 @@ int Camera::getWidthMax()
 // float Camera::getCameraFrameRate()
 //{
 //}
+Spinnaker::GenApi::CNodePtr
+Camera::readProperty(const Spinnaker::GenICam::gcstring property_name) {
+  Spinnaker::GenApi::CNodePtr ptr = node_map_->GetNode(property_name);
+  if (!Spinnaker::GenApi::IsAvailable(ptr) ||
+      !Spinnaker::GenApi::IsReadable(ptr)) {
+    throw std::runtime_error("Unable to get parmeter " + property_name);
+  }
+  return ptr;
+}
 
 Camera::Camera(Spinnaker::GenApi::INodeMap* node_map)
 {

--- a/spinnaker_camera_driver/src/camera.cpp
+++ b/spinnaker_camera_driver/src/camera.cpp
@@ -149,12 +149,12 @@ void Camera::setNewConfiguration(const SpinnakerConfig& config, const uint32_t& 
     {
       setProperty(node_map_, "BalanceWhiteAuto", config.auto_white_balance);
       if (config.auto_white_balance.compare(std::string("Off")) == 0)
-        {
-          setProperty(node_map_, "BalanceRatioSelector", "Blue");
-          setProperty(node_map_, "BalanceRatio", static_cast<float>(config.white_balance_blue_ratio));
-          setProperty(node_map_, "BalanceRatioSelector", "Red");
-          setProperty(node_map_, "BalanceRatio", static_cast<float>(config.white_balance_red_ratio));
-        }
+      {
+        setProperty(node_map_, "BalanceRatioSelector", "Blue");
+        setProperty(node_map_, "BalanceRatio", static_cast<float>(config.white_balance_blue_ratio));
+        setProperty(node_map_, "BalanceRatioSelector", "Red");
+        setProperty(node_map_, "BalanceRatio", static_cast<float>(config.white_balance_red_ratio));
+      }
     }
   }
   catch (const Spinnaker::Exception& e)

--- a/spinnaker_camera_driver/src/diagnostics.cpp
+++ b/spinnaker_camera_driver/src/diagnostics.cpp
@@ -1,0 +1,152 @@
+/**
+Software License Agreement (BSD)
+
+\file      diagnostics.cpp
+\authors   Michael Lowe <michael@ascent.ai>
+\copyright Copyright (c) 2018, Ascent Robotics, Inc., All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of Clearpath Robotics nor the names of its contributors may
+   be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "spinnaker_camera_driver/diagnostics.h"
+
+namespace spinnaker_camera_driver {
+
+DiagnosticsManager::DiagnosticsManager(
+    const std::string name, const std::string serial,
+    std::shared_ptr<ros::Publisher> const &pub)
+    : camera_name_(name), serial_number_(serial), diagnostics_pub_(pub) {}
+
+DiagnosticsManager::~DiagnosticsManager() {}
+
+template <typename T>
+void DiagnosticsManager::addDiagnostic(Spinnaker::GenICam::gcstring name) {
+  // Call the overloaded function (use the pair to determine which one)
+  addDiagnostic(name, false, std::make_pair<T, T>(0, 0));
+}
+
+template void
+DiagnosticsManager::addDiagnostic<int>(Spinnaker::GenICam::gcstring name);
+
+template void
+DiagnosticsManager::addDiagnostic<float>(Spinnaker::GenICam::gcstring name);
+
+void DiagnosticsManager::addDiagnostic(Spinnaker::GenICam::gcstring name,
+                                       bool check_ranges,
+                                       std::pair<int, int> operational,
+                                       int lower_bound, int upper_bound) {
+  diagnostic_params<int> param{name, check_ranges, operational, lower_bound,
+                               upper_bound};
+  integer_params_.push_back(param);
+}
+
+void DiagnosticsManager::addDiagnostic(Spinnaker::GenICam::gcstring name,
+                                       bool check_ranges,
+                                       std::pair<float, float> operational,
+                                       float lower_bound, float upper_bound) {
+  diagnostic_params<float> param{name, check_ranges, operational, lower_bound,
+                                 upper_bound};
+  float_params_.push_back(param);
+}
+
+template <typename T>
+void DiagnosticsManager::pushDiagStatus(
+    diagnostic_msgs::DiagnosticArray &diag_array,
+    const diagnostic_params<T> &param, const T value) {
+  diagnostic_msgs::KeyValue kv;
+  kv.key = param.parameter_name;
+  kv.value = std::to_string(value);
+
+  diagnostic_msgs::DiagnosticStatus diag_status;
+  diag_status.values.push_back(kv);
+  diag_status.name = "Spinnaker " +
+                     Spinnaker::GenICam::gcstring(camera_name_.c_str()) + " " +
+                     param.parameter_name;
+  diag_status.hardware_id = serial_number_;
+
+  // Determine status level
+  if (!param.check_ranges || (value > param.operational_range.first &&
+                              value <= param.operational_range.second)) {
+    diag_status.level = 0;
+    diag_status.message = "OK";
+  } else if (value >= param.warn_range_lower &&
+             value <= param.warn_range_upper) {
+    diag_status.level = 1;
+    diag_status.message = "WARNING";
+  } else {
+    diag_status.level = 2;
+    diag_status.message = "ERROR";
+  }
+
+  diag_array.status.push_back(diag_status);
+}
+
+void DiagnosticsManager::processDiagnostics(SpinnakerCamera &spinnaker) {
+  diagnostic_msgs::DiagnosticArray diag_array;
+
+  Spinnaker::GenApi::CStringPtr string_ptr;
+
+
+  // Manufacturer Info
+  diagnostic_msgs::DiagnosticStatus diag_manufacture_info;
+  diag_manufacture_info.name =
+      "Spinnaker " + camera_name_ + " Manufacture Info";
+  diag_manufacture_info.hardware_id = serial_number_;
+
+  for (const std::string param : manufacturer_params_) {
+    Spinnaker::GenApi::CStringPtr string_ptr =
+        static_cast<Spinnaker::GenApi::CStringPtr>(spinnaker.readProperty(
+            Spinnaker::GenICam::gcstring(param.c_str())));
+
+    diagnostic_msgs::KeyValue kv;
+    kv.key = param;
+    kv.value = string_ptr->GetValue(true);
+    diag_manufacture_info.values.push_back(kv);
+  }
+  
+  diag_array.status.push_back(diag_manufacture_info);
+
+   //Float based parameters
+   Spinnaker::GenApi::CFloatPtr float_ptr;
+   for (const diagnostic_params<float>& param : float_params_) {
+     Spinnaker::GenApi::CFloatPtr float_ptr =
+         static_cast<Spinnaker::GenApi::CFloatPtr>(
+             spinnaker.readProperty(param.parameter_name));
+     float float_value = float_ptr->GetValue(true);
+
+     pushDiagStatus(diag_array, param, float_value);
+   }
+
+   //Int based parameters
+   Spinnaker::GenApi::CIntegerPtr integer_ptr;
+   for (const diagnostic_params<int>& param : integer_params_) {
+     Spinnaker::GenApi::CIntegerPtr integer_ptr =
+         static_cast<Spinnaker::GenApi::CIntegerPtr>(
+             spinnaker.readProperty(param.parameter_name));
+     int int_value = integer_ptr->GetValue(true);
+     pushDiagStatus(diag_array, param, int_value);
+   }
+
+   diagnostics_pub_->publish(diag_array);
+}
+}

--- a/spinnaker_camera_driver/src/diagnostics.cpp
+++ b/spinnaker_camera_driver/src/diagnostics.cpp
@@ -86,20 +86,20 @@ diagnostic_msgs::DiagnosticStatus DiagnosticsManager::getDiagStatus(const diagno
 
   // Determine status level
   if (!param.check_ranges || (value > param.operational_range.first && value <= param.operational_range.second))
-    {
-      diag_status.level = 0;
-      diag_status.message = "OK";
-    }
+  {
+    diag_status.level = 0;
+    diag_status.message = "OK";
+  }
   else if (value >= param.warn_range_lower && value <= param.warn_range_upper)
-    {
-      diag_status.level = 1;
-      diag_status.message = "WARNING";
-    }
+  {
+    diag_status.level = 1;
+    diag_status.message = "WARNING";
+  }
   else
-    {
-      diag_status.level = 2;
-      diag_status.message = "ERROR";
-    }
+  {
+    diag_status.level = 2;
+    diag_status.message = "ERROR";
+  }
 
   return diag_status;
 }
@@ -114,42 +114,41 @@ void DiagnosticsManager::processDiagnostics(SpinnakerCamera* spinnaker)
   diag_manufacture_info.hardware_id = serial_number_;
 
   for (const std::string param : manufacturer_params_)
-    {
-      Spinnaker::GenApi::CStringPtr string_ptr = static_cast<Spinnaker::GenApi::CStringPtr>(
-          spinnaker->readProperty(Spinnaker::GenICam::gcstring(param.c_str())));
+  {
+    Spinnaker::GenApi::CStringPtr string_ptr = static_cast<Spinnaker::GenApi::CStringPtr>(
+        spinnaker->readProperty(Spinnaker::GenICam::gcstring(param.c_str())));
 
-      diagnostic_msgs::KeyValue kv;
-      kv.key = param;
-      kv.value = string_ptr->GetValue(true);
-      diag_manufacture_info.values.push_back(kv);
-    }
+    diagnostic_msgs::KeyValue kv;
+    kv.key = param;
+    kv.value = string_ptr->GetValue(true);
+    diag_manufacture_info.values.push_back(kv);
+  }
 
   diag_array.status.push_back(diag_manufacture_info);
 
-      // Float based parameters
-      for (const diagnostic_params<float>& param : float_params_)
-      {
-        Spinnaker::GenApi::CFloatPtr float_ptr =
-            static_cast<Spinnaker::GenApi::CFloatPtr>(spinnaker->readProperty(param.parameter_name));
+  // Float based parameters
+  for (const diagnostic_params<float>& param : float_params_)
+  {
+    Spinnaker::GenApi::CFloatPtr float_ptr =
+        static_cast<Spinnaker::GenApi::CFloatPtr>(spinnaker->readProperty(param.parameter_name));
 
-        float float_value = float_ptr->GetValue(true);
+    float float_value = float_ptr->GetValue(true);
 
-        diagnostic_msgs::DiagnosticStatus diag_status = getDiagStatus(param, float_value);
-        diag_array.status.push_back(diag_status);
-      }
+    diagnostic_msgs::DiagnosticStatus diag_status = getDiagStatus(param, float_value);
+    diag_array.status.push_back(diag_status);
+  }
 
-      // Int based parameters
-      for (const diagnostic_params<int>& param : integer_params_)
-      {
-        Spinnaker::GenApi::CIntegerPtr integer_ptr =
-            static_cast<Spinnaker::GenApi::CIntegerPtr>(spinnaker->readProperty(param.parameter_name));
+  // Int based parameters
+  for (const diagnostic_params<int>& param : integer_params_)
+  {
+    Spinnaker::GenApi::CIntegerPtr integer_ptr =
+        static_cast<Spinnaker::GenApi::CIntegerPtr>(spinnaker->readProperty(param.parameter_name));
 
-        int int_value = integer_ptr->GetValue(true);
-        diagnostic_msgs::DiagnosticStatus diag_status = getDiagStatus(param, int_value);
-        diag_array.status.push_back(diag_status);
-      }
+    int int_value = integer_ptr->GetValue(true);
+    diagnostic_msgs::DiagnosticStatus diag_status = getDiagStatus(param, int_value);
+    diag_array.status.push_back(diag_status);
+  }
 
   diagnostics_pub_->publish(diag_array);
 }
 }  // namespace spinnaker_camera_driver
-

--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -51,7 +51,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <pluginlib/class_list_macros.h>
 #include <nodelet/nodelet.h>
 
-#include "spinnaker_camera_driver/SpinnakerCamera.h" // The actual standalone library for the Spinnakers
+#include "spinnaker_camera_driver/SpinnakerCamera.h"  // The actual standalone library for the Spinnakers
 #include "spinnaker_camera_driver/diagnostics.h"
 
 #include <image_transport/image_transport.h>          // ROS library that allows sending compressed images
@@ -84,7 +84,8 @@ public:
   {
     std::lock_guard<std::mutex> scopedLock(connect_mutex_);
 
-    if (diagThread_) {
+    if (diagThread_)
+    {
       diagThread_->interrupt();
       diagThread_->join();
     }
@@ -167,12 +168,13 @@ private:
     }
   }
 
-  void diagCb() {
-    if (!diagThread_) // We need to connect
+  void diagCb()
+  {
+    if (!diagThread_)  // We need to connect
     {
       // Start the thread to loop through and publish messages
-      diagThread_.reset(new boost::thread(boost::bind(
-          &spinnaker_camera_driver::SpinnakerCameraNodelet::diagPoll, this)));
+      diagThread_.reset(
+          new boost::thread(boost::bind(&spinnaker_camera_driver::SpinnakerCameraNodelet::diagPoll, this)));
     }
   }
 
@@ -363,16 +365,10 @@ private:
 
     diag_man = std::unique_ptr<DiagnosticsManager>(new DiagnosticsManager(
         frame_id_, std::to_string(spinnaker_.getSerial()), diagnostics_pub_));
-    diag_man->addDiagnostic("DeviceTemperature", true,
-                            std::make_pair<float, float>(0.0, 90.0), -10.0,
-                            95.0);
-    diag_man->addDiagnostic("AcquisitionResultingFrameRate", true,
-                            std::make_pair<float, float>(10.0, 60.0), 5.0,
-                            90.0);
-    diag_man->addDiagnostic("PowerSupplyVoltage", true,
-                            std::make_pair<float, float>(4.5, 5.2), 4.4, 5.3);
-    diag_man->addDiagnostic("PowerSupplyCurrent", true,
-                            std::make_pair<float, float>(0.4, 0.6), 0.3, 1.0);
+    diag_man->addDiagnostic("DeviceTemperature", true, std::make_pair(0.0f, 90.0f), -10.0f, 95.0f);
+    diag_man->addDiagnostic("AcquisitionResultingFrameRate", true, std::make_pair(10.0f, 60.0f), 5.0f, 90.0f);
+    diag_man->addDiagnostic("PowerSupplyVoltage", true, std::make_pair(4.5f, 5.2f), 4.4f, 5.3f);
+    diag_man->addDiagnostic("PowerSupplyCurrent", true, std::make_pair(0.4f, 0.6f), 0.3f, 1.0f);
     diag_man->addDiagnostic<int>("DeviceUptime");
     diag_man->addDiagnostic<int>("U3VMessageChannelID");
   }
@@ -407,12 +403,13 @@ private:
     return 0;
   }
 
-  void diagPoll() {
-    while (!boost::this_thread::interruption_requested()) // Block until we need
-                                                          // to stop this
-                                                          // thread.
+  void diagPoll()
+  {
+    while (!boost::this_thread::interruption_requested())  // Block until we need
+                                                           // to stop this
+                                                           // thread.
     {
-      diag_man->processDiagnostics(spinnaker_);
+      diag_man->processDiagnostics(&spinnaker_);
     }
   }
 
@@ -686,8 +683,7 @@ private:
   sensor_msgs::CameraInfoPtr ci_;  ///< Camera Info message.
   std::string frame_id_;           ///< Frame id for the camera messages, defaults to 'camera'
   std::shared_ptr<boost::thread> pubThread_;  ///< The thread that reads and publishes the images.
-  std::shared_ptr<boost::thread>
-      diagThread_; ///< The thread that reads and publishes the diagnostics.
+  std::shared_ptr<boost::thread> diagThread_;  ///< The thread that reads and publishes the diagnostics.
 
   std::unique_ptr<DiagnosticsManager> diag_man;
 

--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -51,7 +51,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <pluginlib/class_list_macros.h>
 #include <nodelet/nodelet.h>
 
-#include "spinnaker_camera_driver/SpinnakerCamera.h"  // The actual standalone library for the Spinnakers
+#include "spinnaker_camera_driver/SpinnakerCamera.h" // The actual standalone library for the Spinnakers
+#include "spinnaker_camera_driver/diagnostics.h"
 
 #include <image_transport/image_transport.h>          // ROS library that allows sending compressed images
 #include <camera_info_manager/camera_info_manager.h>  // ROS library that publishes CameraInfo topics
@@ -82,6 +83,11 @@ public:
   ~SpinnakerCameraNodelet()
   {
     std::lock_guard<std::mutex> scopedLock(connect_mutex_);
+
+    if (diagThread_) {
+      diagThread_->interrupt();
+      diagThread_->join();
+    }
 
     if (pubThread_)
     {
@@ -158,6 +164,15 @@ private:
     catch (std::runtime_error& e)
     {
       NODELET_ERROR("Reconfigure Callback failed with error: %s", e.what());
+    }
+  }
+
+  void diagCb() {
+    if (!diagThread_) // We need to connect
+    {
+      // Start the thread to loop through and publish messages
+      diagThread_.reset(new boost::thread(boost::bind(
+          &spinnaker_camera_driver::SpinnakerCameraNodelet::diagPoll, this)));
     }
   }
 
@@ -331,10 +346,35 @@ private:
     double max_acceptable;  // The maximum publishing delay (in seconds) before warning.
     pnh.param<double>("max_acceptable_delay", max_acceptable, 0.2);
     ros::SubscriberStatusCallback cb2 = boost::bind(&SpinnakerCameraNodelet::connectCb, this);
-    pub_.reset(new diagnostic_updater::DiagnosedPublisher<wfov_camera_msgs::WFOVImage>(
-        nh.advertise<wfov_camera_msgs::WFOVImage>("image", 5, cb2, cb2), updater_,
-        diagnostic_updater::FrequencyStatusParam(&min_freq_, &max_freq_, freq_tolerance, window_size),
-        diagnostic_updater::TimeStampStatusParam(min_acceptable, max_acceptable)));
+    pub_.reset(
+        new diagnostic_updater::DiagnosedPublisher<wfov_camera_msgs::WFOVImage>(
+            nh.advertise<wfov_camera_msgs::WFOVImage>("image", 5, cb2, cb2),
+            updater_, diagnostic_updater::FrequencyStatusParam(
+                          &min_freq_, &max_freq_, freq_tolerance, window_size),
+            diagnostic_updater::TimeStampStatusParam(min_acceptable,
+                                                     max_acceptable)));
+
+    // Set up diagnostics aggregator publisher and diagnostics manager
+    ros::SubscriberStatusCallback diag_cb =
+        boost::bind(&SpinnakerCameraNodelet::diagCb, this);
+    diagnostics_pub_.reset(
+        new ros::Publisher(nh.advertise<diagnostic_msgs::DiagnosticArray>(
+            "/diagnostics", 1, diag_cb, diag_cb)));
+
+    diag_man = std::unique_ptr<DiagnosticsManager>(new DiagnosticsManager(
+        frame_id_, std::to_string(spinnaker_.getSerial()), diagnostics_pub_));
+    diag_man->addDiagnostic("DeviceTemperature", true,
+                            std::make_pair<float, float>(0.0, 90.0), -10.0,
+                            95.0);
+    diag_man->addDiagnostic("AcquisitionResultingFrameRate", true,
+                            std::make_pair<float, float>(10.0, 60.0), 5.0,
+                            90.0);
+    diag_man->addDiagnostic("PowerSupplyVoltage", true,
+                            std::make_pair<float, float>(4.5, 5.2), 4.4, 5.3);
+    diag_man->addDiagnostic("PowerSupplyCurrent", true,
+                            std::make_pair<float, float>(0.4, 0.6), 0.3, 1.0);
+    diag_man->addDiagnostic<int>("DeviceUptime");
+    diag_man->addDiagnostic<int>("U3VMessageChannelID");
   }
 
   /**
@@ -365,6 +405,15 @@ private:
 
     NODELET_WARN_ONCE("Unable to open serial path: %s", camera_serial_path.c_str());
     return 0;
+  }
+
+  void diagPoll() {
+    while (!boost::this_thread::interruption_requested()) // Block until we need
+                                                          // to stop this
+                                                          // thread.
+    {
+      diag_man->processDiagnostics(spinnaker_);
+    }
   }
 
   /*!
@@ -620,6 +669,7 @@ private:
                                                                    /// CameraInfoManager in scope.
   image_transport::CameraPublisher it_pub_;                        ///< CameraInfoManager ROS publisher
   std::shared_ptr<diagnostic_updater::DiagnosedPublisher<wfov_camera_msgs::WFOVImage> > pub_;  ///< Diagnosed
+  std::shared_ptr<ros::Publisher> diagnostics_pub_;
   /// publisher, has to be
   /// a pointer because of
   /// constructor
@@ -636,6 +686,10 @@ private:
   sensor_msgs::CameraInfoPtr ci_;  ///< Camera Info message.
   std::string frame_id_;           ///< Frame id for the camera messages, defaults to 'camera'
   std::shared_ptr<boost::thread> pubThread_;  ///< The thread that reads and publishes the images.
+  std::shared_ptr<boost::thread>
+      diagThread_; ///< The thread that reads and publishes the diagnostics.
+
+  std::unique_ptr<DiagnosticsManager> diag_man;
 
   double gain_;
   uint16_t wb_blue_;


### PR DESCRIPTION
This is to support feeding the diagnostics aggregator with values specified in the nodelet.cpp file to make it easy to check things like temperature, voltage, and framerate. You can easily check these by using "rosrun rqt_robot_monitor rqt_robot_monitor"