### PR TITLE
Add missing target (Cm3) and switch to find_package script.

### DIFF
--- a/spinnaker_camera_driver/CMakeLists.txt
+++ b/spinnaker_camera_driver/CMakeLists.txt
@@ -28,12 +28,13 @@ catkin_package(CATKIN_DEPENDS
 # the Point Grey EULA prohibits redistributing the headers or the packages which
 # contains them. We work around this by downloading the archive directly from
 # their website during this step in the build process.
-find_library(Spinnaker_LIBRARIES Spinnaker)
-# if(NOT Spinnaker_LIBRARIES)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+find_package(Spinnaker QUIET)
+if(NOT Spinnaker_LIBRARIES)
   message(STATUS "libSpinnaker not found in system library path")
   include(cmake/DownloadSpinnaker.cmake)
   download_spinnaker(Spinnaker_LIBRARIES Spinnaker_INCLUDE_DIRS)
-# endif()
+endif()
 
 message(STATUS "libSpinnaker library: ${Spinnaker_LIBRARIES}")
 message(STATUS "libSpinnaker include: ${Spinnaker_INCLUDE_DIRS}")
@@ -92,6 +93,7 @@ install(TARGETS
   SpinnakerCameraLib
   SpinnakerCameraNodelet
   Camera
+  Cm3
   Diagnostics
   spinnaker_camera_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/spinnaker_camera_driver/cmake/modules/FindSpinnaker.cmake
+++ b/spinnaker_camera_driver/cmake/modules/FindSpinnaker.cmake
@@ -1,0 +1,19 @@
+unset(Spinnaker_FOUND)
+unset(Spinnaker_INCLUDE_DIRS)
+unset(Spinnaker_LIBRARIES)
+
+find_path(Spinnaker_INCLUDE_DIRS NAMES
+  Spinnaker.h
+  HINTS
+  /usr/include/spinnaker/
+  /usr/local/include/spinnaker/)
+message(STATUS "Did we find it? ${SPINNAKER_INCLUDE_DIRS}")
+
+find_library(Spinnaker_LIBRARIES NAMES Spinnaker
+    HINTS
+    /usr/lib
+    /usr/local/lib)
+
+if (Spinnaker_INCLUDE_DIRS AND Spinnaker_LIBRARIES)
+  set(Spinnaker_FOUND 1)
+endif (Spinnaker_INCLUDE_DIRS AND Spinnaker_LIBRARIES)

--- a/spinnaker_camera_driver/cmake/modules/FindSpinnaker.cmake
+++ b/spinnaker_camera_driver/cmake/modules/FindSpinnaker.cmake
@@ -7,7 +7,6 @@ find_path(Spinnaker_INCLUDE_DIRS NAMES
   HINTS
   /usr/include/spinnaker/
   /usr/local/include/spinnaker/)
-message(STATUS "Did we find it? ${SPINNAKER_INCLUDE_DIRS}")
 
 find_library(Spinnaker_LIBRARIES NAMES Spinnaker
     HINTS


### PR DESCRIPTION
This fixes 2 issues I encountered while trying to run the library from the pre-built kinetic version on Ubuntu 16.04.

1. libCm3.so isn't exported/installed properly, so the nodelet was failing to load when trying to launch camera.launch
   a. Fix: export Cm3 as an install target.
2. My pre-installed version of the Spinnaker SDK wasn't being found (or wasn't finding the include directories) when trying to build from source.
   b. Fix: switch to find_package and provide a cmake find script.
   c. Fix: also find the include directories in the package script.

Let me know if you're ok with the cmake script, otherwise I can take it out but definitely Cm3 should be installed as a target.

With these fixes, it works fine for me from source with an self-installed SDK. :)