### PR TITLE
Fixes SpinnakerCamera teardown

### DIFF
--- a/spinnaker_camera_driver/src/SpinnakerCamera.cpp
+++ b/spinnaker_camera_driver/src/SpinnakerCamera.cpp
@@ -66,8 +66,8 @@ SpinnakerCamera::SpinnakerCamera()
 
 SpinnakerCamera::~SpinnakerCamera()
 {
-  camList_.Clear();
-  system_->ReleaseInstance();
+  // camList_.Clear();
+  // system_->ReleaseInstance();
 }
 
 void SpinnakerCamera::setNewConfiguration(const spinnaker_camera_driver::SpinnakerConfig& config, const uint32_t& level)

--- a/spinnaker_camera_driver/src/SpinnakerCamera.cpp
+++ b/spinnaker_camera_driver/src/SpinnakerCamera.cpp
@@ -66,8 +66,7 @@ SpinnakerCamera::SpinnakerCamera()
 
 SpinnakerCamera::~SpinnakerCamera()
 {
-  // camList_.Clear();
-  // system_->ReleaseInstance();
+  // @note ebretl Destructors of camList_ and system_ handle teardown
 }
 
 void SpinnakerCamera::setNewConfiguration(const spinnaker_camera_driver::SpinnakerConfig& config, const uint32_t& level)


### PR DESCRIPTION
Fixes #15. Please review the issue description before the following.

Running the nodelet manager in valgrind shows that the crash is happening in the destructor of SpinnakerCamera's system_ object, which is calling ReleaseInstance for a second time. Removing the first call prevents the crash from occuring and the "something still has a reference to the camera" error from appearing in the console. 

Through trial and error, removing camList_.Clear() was found to prevent a further issue where all nodelets under the nodelet manager will break their bonds and exit after about 10 seconds. I have no explanation for this behavior. 

With the default destructor, everything seems to be cleaned up in a way that allows the nodelets and manager to start cleanly the next time. 

I am aware that the Spinnaker API example code uses Clear() and ReleaseInstance(), and I hope that this fix generalizes to other setups. Can someone confirm that this does not break things for you?