### PR TITLE
Update Spinnaker.cfg

### DIFF
--- a/spinnaker_camera_driver/cfg/Spinnaker.cfg
+++ b/spinnaker_camera_driver/cfg/Spinnaker.cfg
@@ -76,7 +76,7 @@ gen = ParameterGenerator()
 
 #       Name                                    Type          Reconfiguration level                  Description                                                                                        Default                     Min      Max
 gen.add("acquisition_frame_rate",                double_t,    SensorLevels.RECONFIGURE_RUNNING,     "User controlled acquisition frame rate in Hertz (frames per second).",                             10,                          0,        120)
-gen.add("acquisition_frame_rate_enable",         bool_t,      SensorLevels.RECONFIGURE_RUNNING,     "Enables manual (true) and automatic (false) control of the aquisition frame rate",                 False)
+gen.add("acquisition_frame_rate_enable",         bool_t,      SensorLevels.RECONFIGURE_RUNNING,     "Enables manual (True) and automatic (False) control of the aquisition frame rate",                 False)
 
 
 # Set Exposure


### PR DESCRIPTION
Fix Description of "acquisition_frame_rate_enable": correct spelling with capital letter of bool type.
Confusing difference in spelling between description and bool type 