### PR TITLE
Add auto exposure ROI parameters

### DIFF
--- a/spinnaker_camera_driver/cfg/Spinnaker.cfg
+++ b/spinnaker_camera_driver/cfg/Spinnaker.cfg
@@ -288,4 +288,19 @@ line_modes = gen.enum([gen.const("Input", str_t, "Input", ""),
 gen.add("line_mode", str_t, SensorLevels.RECONFIGURE_RUNNING, "Line Mode", "Input", edit_method = line_modes)
 
 
+# Auto algorithm parameters
+gen.add("auto_exposure_roi_offset_x", int_t, SensorLevels.RECONFIGURE_RUNNING, "Auto exposure ROI X offset.", 0, 0, 65535)
+gen.add("auto_exposure_roi_offset_y", int_t, SensorLevels.RECONFIGURE_RUNNING, "Auto exposure ROI Y offset.", 0, 0, 65535)
+gen.add("auto_exposure_roi_width", int_t, SensorLevels.RECONFIGURE_RUNNING, "Auto exposure ROI width.", 0, 0, 65535)
+gen.add("auto_exposure_roi_height", int_t, SensorLevels.RECONFIGURE_RUNNING, "Auto exposure ROI height.", 0, 0, 65535)
+
+auto_lighting_mode = gen.enum([
+    gen.const("Normal", str_t, "Normal", "Normal"),
+    gen.const("Frontlight", str_t, "Frontlight", "Front Lighting"),
+    gen.const("Backlight", str_t, "Backlight", "Back Lighting")
+], "Auto algorithms lighting modes")
+gen.add("auto_exposure_lighting_mode", str_t, SensorLevels.RECONFIGURE_RUNNING, "Auto exposure lighting mode.", "Normal", edit_method=auto_lighting_mode)
+
+
+
 exit(gen.generate(PACKAGE, "spinnaker_camera_driver", "Spinnaker"))

--- a/spinnaker_camera_driver/include/spinnaker_camera_driver/set_property.h
+++ b/spinnaker_camera_driver/include/spinnaker_camera_driver/set_property.h
@@ -88,6 +88,17 @@ inline bool setProperty(Spinnaker::GenApi::INodeMap* node_map, const std::string
         ROS_WARN_STREAM("[SpinnakerCamera]: ("
                         << static_cast<Spinnaker::GenApi::CStringPtr>(node_map->GetNode("DeviceID"))->GetValue()
                         << ") Entry name " << entry_name << " not available.");
+
+        ROS_WARN("Available:");
+        Spinnaker::GenApi::NodeList_t entries;
+        enumerationPtr->GetEntries(entries);
+        for (auto& entry : entries)
+        {
+          auto enumEntry = dynamic_cast<Spinnaker::GenApi::IEnumEntry*>(entry);
+          if (enumEntry && Spinnaker::GenApi::IsAvailable(entry))
+            ROS_WARN_STREAM(" - " << entry->GetName() << " (display " << entry->GetDisplayName() << ", symbolic "
+                                  << enumEntry->GetSymbolic() << ")");
+        }
       }
     }
     else

--- a/spinnaker_camera_driver/src/camera.cpp
+++ b/spinnaker_camera_driver/src/camera.cpp
@@ -156,6 +156,26 @@ void Camera::setNewConfiguration(const SpinnakerConfig& config, const uint32_t& 
         setProperty(node_map_, "BalanceRatio", static_cast<float>(config.white_balance_red_ratio));
       }
     }
+
+    // Set Auto exposure/white balance parameters
+    if (IsAvailable(node_map_->GetNode("AutoAlgorithmSelector")))
+    {
+      setProperty(node_map_, "AutoAlgorithmSelector", std::string("Ae"));
+      setProperty(node_map_, "AasRoiEnable", true);
+      if (config.auto_exposure_roi_width != 0 && config.auto_exposure_roi_height != 0)
+      {
+        setProperty(node_map_, "AasRoiOffsetX", config.auto_exposure_roi_offset_x);
+        setProperty(node_map_, "AasRoiOffsetY", config.auto_exposure_roi_offset_y);
+        setProperty(node_map_, "AasRoiWidth", config.auto_exposure_roi_width);
+        setProperty(node_map_, "AasRoiHeight", config.auto_exposure_roi_height);
+      }
+    }
+
+    // Set Auto exposure lighting mode
+    if (IsAvailable(node_map_->GetNode("AutoExposureLightingMode")))
+    {
+      setProperty(node_map_, "AutoExposureLightingMode", config.auto_exposure_lighting_mode);
+    }
   }
   catch (const Spinnaker::Exception& e)
   {


### PR DESCRIPTION
This is highly useful when using fisheye lenses, which illuminate only a circle in the center of the image. The AE gets confused by the black regions around it and overexposes the image.

This also exposes the `AutoExposureLightingMode` parameter, which allows the user to choose a lighting preset (front/back/normal).

Finally, I modified the `setProperty` method for enumerations to show the available enum values in case the chosen one cannot be found. This is useful for finding out possible enum values for new camera models.