### PR TITLE
Increase limit of exposure

### DIFF
--- a/spinnaker_camera_driver/cfg/Spinnaker.cfg
+++ b/spinnaker_camera_driver/cfg/Spinnaker.cfg
@@ -83,8 +83,8 @@ gen.add("acquisition_frame_rate_enable",         bool_t,      SensorLevels.RECON
 # Note: For the Auto Exposure feature, gain and/or exposure time must be set to Once or Continuous.
 gen.add("exposure_mode",                         str_t,       SensorLevels.RECONFIGURE_STOP,        "Sets the operation mode of the Exposure (Timed or TriggerWidth).",                                 "Timed")
 gen.add("exposure_auto",                         str_t,       SensorLevels.RECONFIGURE_RUNNING,     "Sets the automatic exposure mode to: 'Off', 'Once' or 'Continuous'",                               "Continuous")
-gen.add("exposure_time",                         double_t,    SensorLevels.RECONFIGURE_RUNNING,     "Exposure time in microseconds when Exposure Mode is Timed and Exposure Auto is not Continuous.",                                        100.0,                        0.0,     32754.0)
-gen.add("auto_exposure_time_upper_limit",        double_t,    SensorLevels.RECONFIGURE_RUNNING,     "Upper Limit on Shutter Speed.",                                                                     5000,                         0.0,     32754)
+gen.add("exposure_time",                         double_t,    SensorLevels.RECONFIGURE_RUNNING,     "Exposure time in microseconds when Exposure Mode is Timed and Exposure Auto is not Continuous.",                                        100.0,                        0.0,     3000000.0)
+gen.add("auto_exposure_time_upper_limit",        double_t,    SensorLevels.RECONFIGURE_RUNNING,     "Upper Limit on Shutter Speed.",                                                                     5000,                         0.0,     3000000.0)
 
 
 # Gain Settings


### PR DESCRIPTION
The current maximum value of exposure is quite lower than device limit.
Especially for capturing image in dark environment, it may be too low.
I tested using Blackfly S, that the exposure can be increased to at least 3000000.0 .