### PR TITLE
Add /opt/spinnaker to spinnaker discovery options

### DIFF
--- a/spinnaker_camera_driver/cmake/modules/FindSpinnaker.cmake
+++ b/spinnaker_camera_driver/cmake/modules/FindSpinnaker.cmake
@@ -7,12 +7,14 @@ find_path(Spinnaker_INCLUDE_DIRS NAMES
   PATHS
   /usr/include/spinnaker/
   /usr/local/include/spinnaker/
+  /opt/spinnaker/include/
 )
 
 find_library(Spinnaker_LIBRARIES NAMES Spinnaker
   PATHS
   /usr/lib
   /usr/local/lib
+  /opt/spinnaker/lib
 )
 
 if (Spinnaker_INCLUDE_DIRS AND Spinnaker_LIBRARIES)


### PR DESCRIPTION
Quick fix for finding `spinnaker` (tested using the current SDK version: `2.2.0.48` from [here](https://meta.box.lenovo.com/v/link/view/a1995795ffba47dbbe45771477319cc3)

Closes #59 