### PR TITLE
Correct decoding of RGB from Grasshopper3 camera

### DIFF
--- a/spinnaker_camera_driver/launch/stereo copy.launch
+++ b/spinnaker_camera_driver/launch/stereo copy.launch
@@ -1,0 +1,126 @@
+<?xml version="1.0"?>
+<!--
+Software License Agreement (BSD)
+
+\file      stereo.launch
+\authors   Michael Hosmar <mhosmar@clearpathrobotics.com>
+\copyright Copyright (c) 2018, Clearpath Robotics, Inc., All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+   following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the 
+   following disclaimer in the documentation and/or other materials provided with the distribution.
+ * Neither the name of Clearpath Robotics nor the names of its contributors may be used to endorse or promote
+   products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WAR-
+RANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, IN-
+DIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<launch>
+  <!-- Common parameters -->
+  <arg name="camera_name"               default="camera_array" />
+
+  <!-- When unspecified, the driver will use the default framerate as given by the
+      camera itself. Use the parameter 'control_frame_rate' to enable manual frame 
+      rate control, and 'frame_rate' to set the frame rate value. -->
+  <arg name="control_frame_rate"        default="true" />
+  <arg name="frame_rate"                default="10" />
+
+  <arg name="left_camera_serial"        default="17581531" />
+  <arg name="left_camera_calibrated"    default="0" />
+
+  <arg name="right_camera_serial"       default="17581532" />
+  <arg name="right_camera_calibrated"   default="0" />
+
+  <arg name="run_stereo_image_proc"     default="false" />
+
+  <!-- Nodelet manager -->
+  <!-- Both cameras are not loaded into one nodelet manager to avoid the namespacing issue. -->
+  <node pkg="nodelet" type="nodelet" name="camera_nodelet_manager" args="manager" />
+
+  <group ns="$(arg camera_name)" >
+    <group ns="left" >
+      <!-- Camera nodelet -->
+      <node pkg="nodelet" type="nodelet" name="camera_nodelet"
+            args="load spinnaker_camera_driver/SpinnakerCameraNodelet /camera_nodelet_manager" >
+        <param name="frame_id"                        value="camera_left" />
+        <param name="serial"                          value="$(arg left_camera_serial)" />
+
+        <!-- Frame rate -->
+        <param name="acquisition_frame_rate_enable"   value="$(arg control_frame_rate)" />
+        <param name="acquisition_frame_rate"          value="$(arg frame_rate)" />
+        <param name="enable_trigger"                  value="Off" />
+        <param name="exposure_mode"                   value="Timed" />
+        <param name="exposure_auto"                   value="Off" />
+        <param name="exposure_time"                   value="20000.0" />
+        <param name="auto_gain"                       value="Off" />
+        <param name="gain"                            value="30" />
+        <param name="white_balance_blue_ratio"        value="1.96" />
+        <param name="white_balance_red_ratio"         value="1.55" />
+        <param name="line_selector"                   value="Line1" />
+        <param name="line_mode"                       value="Output" />
+        <param name="line_source"                     value="ExposureActive" />
+        <param name="image_format_color_coding"       value="RGB8" />
+
+        <!-- Use the camera_calibration package to create this file -->
+        <param name="camera_info_url" if="$(arg left_camera_calibrated)"
+               value="file://$(env HOME)/.ros/camera_info/$(arg left_camera_serial).yaml" />
+      </node>
+
+      <!-- Debayering nodelet -->
+      <node pkg="nodelet" type="nodelet" name="image_proc_debayer"
+          args="load image_proc/debayer /camera_nodelet_manager">
+      </node>
+    </group>
+
+    <group ns="right" >
+      <!-- Camera nodelet -->
+      <node pkg="nodelet" type="nodelet" name="camera_nodelet"
+            args="load spinnaker_camera_driver/SpinnakerCameraNodelet /camera_nodelet_manager" >
+        <param name="frame_id"                        value="camera_right" />
+        <param name="serial"                          value="$(arg right_camera_serial)" />
+
+        <!-- Frame rate -->
+        <param name="acquisition_frame_rate_enable"   value="false" />
+        <param name="acquisition_frame_rate"          value="1" />
+        <param name="enable_trigger"                  value="On" />
+        <param name="trigger_source"                  value="Line0" />
+
+        <param name="exposure_mode"                   value="Timed" />
+        <param name="exposure_auto"                   value="Off" />
+        <param name="exposure_time"                   value="20000.0" />
+        <param name="auto_gain"                       value="Off" />
+        <param name="gain"                            value="30" />
+        <param name="white_balance_blue_ratio"        value="1.96" />
+        <param name="white_balance_red_ratio"         value="1.55" />
+        <param name="line_selector"                   value="Line0" />
+        <param name="line_mode"                       value="Input" />
+        <param name="image_format_color_coding"       value="RGB8" />
+
+        <!-- Use the camera_calibration package to create this file -->
+        <param name="camera_info_url" if="$(arg right_camera_calibrated)"
+               value="file://$(env HOME)/.ros/camera_info/$(arg right_camera_serial).yaml" />
+      </node>
+
+      <!-- Debayering nodelet -->
+      <node pkg="nodelet" type="nodelet" name="image_proc_debayer"
+          args="load image_proc/debayer /camera_nodelet_manager">
+      </node>
+    </group>
+
+    <!-- Stereo image processing nodelet -->
+    <group if="$(arg run_stereo_image_proc)" >
+      <node pkg="stereo_image_proc" type="stereo_image_proc" name="stereo_image_proc">
+        <param name="approximate_sync" value="true"/>
+      </node>
+    </group>
+
+  </group>
+</launch>

--- a/spinnaker_camera_driver/src/SpinnakerCamera.cpp
+++ b/spinnaker_camera_driver/src/SpinnakerCamera.cpp
@@ -40,14 +40,14 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    @attention Carnegie Mellon University
 */
 
-#include "spinnaker_camera_driver/SpinnakerCamera.h"
+#include <ros/ros.h>
 
 #include <iostream>
 #include <sstream>
-#include <typeinfo>
 #include <string>
+#include <typeinfo>
 
-#include <ros/ros.h>
+#include "spinnaker_camera_driver/SpinnakerCamera.h"
 
 namespace spinnaker_camera_driver
 {
@@ -362,7 +362,8 @@ void SpinnakerCamera::grabImage(sensor_msgs::Image* image, const std::string& fr
         Spinnaker::GenICam::gcstring bayer_bg_str = "BayerBG";
 
         // if(isColor_ && bayer_format != NONE)
-        if (color_filter_ptr->GetCurrentEntry() != color_filter_ptr->GetEntryByName("None"))
+        if (color_filter_ptr->GetCurrentEntry() != color_filter_ptr->GetEntryByName("None") and
+            (bitsPerPixel == 16 or bitsPerPixel == 8))
         {
           if (bitsPerPixel == 16)
           {

--- a/spinnaker_camera_driver/src/gh3.cpp
+++ b/spinnaker_camera_driver/src/gh3.cpp
@@ -66,6 +66,7 @@ void Gh3::setNewConfiguration(const SpinnakerConfig& config, const uint32_t& lev
     if (level >= LEVEL_RECONFIGURE_STOP)
       setImageControlFormats(config);
 
+    setProperty(node_map_, "TriggerMode", std::string("Off"));
     setFrameRate(static_cast<float>(config.acquisition_frame_rate));
     setProperty(node_map_, "AcquisitionFrameRateEnabled",
                 config.acquisition_frame_rate_enable);  // Set enable after frame rate encase its false
@@ -73,15 +74,14 @@ void Gh3::setNewConfiguration(const SpinnakerConfig& config, const uint32_t& lev
     // Set Trigger and Strobe Settings
     // NOTE: The trigger must be disabled (i.e. TriggerMode = "Off") in order to configure whether the source is
     // software or hardware.
-    setProperty(node_map_, "TriggerMode", std::string("Off"));
     setProperty(node_map_, "TriggerSource", config.trigger_source);
     setProperty(node_map_, "TriggerSelector", config.trigger_selector);
     setProperty(node_map_, "TriggerActivation", config.trigger_activation_mode);
-    setProperty(node_map_, "TriggerMode", config.enable_trigger);
 
     setProperty(node_map_, "LineSelector", config.line_selector);
     setProperty(node_map_, "LineMode", config.line_mode);
-    // setProperty(node_map_, "LineSource", config.line_source); // Not available in GH3
+    //The enumeration is not available, but the node is, accessing it sets a default value enabling output
+    setProperty(node_map_, "LineSource", config.line_source); // Not available in GH3
 
     // Set auto exposure
     setProperty(node_map_, "ExposureMode", config.exposure_mode);
@@ -150,6 +150,8 @@ void Gh3::setNewConfiguration(const SpinnakerConfig& config, const uint32_t& lev
         setProperty(node_map_, "BalanceRatio", static_cast<float>(config.white_balance_red_ratio));
       }
     }
+
+    setProperty(node_map_, "TriggerMode", config.enable_trigger);
   }
   catch (const Spinnaker::Exception& e)
   {

--- a/spinnaker_camera_driver/src/gh3.cpp
+++ b/spinnaker_camera_driver/src/gh3.cpp
@@ -22,9 +22,9 @@ OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTE
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-#include "spinnaker_camera_driver/gh3.h"
-
 #include <string>
+
+#include "spinnaker_camera_driver/gh3.h"
 
 namespace spinnaker_camera_driver
 {
@@ -144,9 +144,9 @@ void Gh3::setNewConfiguration(const SpinnakerConfig& config, const uint32_t& lev
       setProperty(node_map_, "BalanceWhiteAuto", config.auto_white_balance);
       if (config.auto_white_balance.compare(std::string("Off")) == 0)
       {
-        setProperty(node_map_, "BalanceRatioSelector", "Blue");
+        setProperty(node_map_, "BalanceRatioSelector", std::string("Blue"));
         setProperty(node_map_, "BalanceRatio", static_cast<float>(config.white_balance_blue_ratio));
-        setProperty(node_map_, "BalanceRatioSelector", "Red");
+        setProperty(node_map_, "BalanceRatioSelector", std::string("Red"));
         setProperty(node_map_, "BalanceRatio", static_cast<float>(config.white_balance_red_ratio));
       }
     }


### PR DESCRIPTION
The color_filter_ptr node returns a non-none value (bayerRG) when the Grasshopper3 is used in RGB8 mode.  That resulted in incorrect color decoding when using RGB8.  Just need to check bit depth before considering bayer decoding.  
Also cast "Red" and "Blue" to strings to call correct function.