### PR TITLE
Add support for 3.3V camera output

### DIFF
--- a/spinnaker_camera_driver/cfg/Spinnaker.cfg
+++ b/spinnaker_camera_driver/cfg/Spinnaker.cfg
@@ -288,6 +288,8 @@ line_modes = gen.enum([gen.const("Input", str_t, "Input", ""),
 
 gen.add("line_mode", str_t, SensorLevels.RECONFIGURE_RUNNING, "Line Mode", "Input", edit_method = line_modes)
 
+# Camera 3.3V output parameters
+gen.add("enable_3V_output", bool_t, SensorLevels.RECONFIGURE_RUNNING, "Enable camera 3.3V output.",False)
 
 # Auto algorithm parameters
 gen.add("auto_exposure_roi_offset_x", int_t, SensorLevels.RECONFIGURE_RUNNING, "Auto exposure ROI X offset.", 0, 0, 65535)

--- a/spinnaker_camera_driver/src/camera.cpp
+++ b/spinnaker_camera_driver/src/camera.cpp
@@ -76,6 +76,9 @@ void Camera::setNewConfiguration(const SpinnakerConfig& config, const uint32_t& 
     // Set enable after frame rate encase its false
     setProperty(node_map_, "AcquisitionFrameRateEnable", config.acquisition_frame_rate_enable);
 
+    // Set 3.3V out put to support external circuitry
+    setProperty(node_map_, "V3_3Enable", config.enable_3V_output);
+
     // Set Trigger and Strobe Settings
     // NOTE: The trigger must be disabled (i.e. TriggerMode = "Off") in order to configure whether the source is
     // software or hardware.


### PR DESCRIPTION
This enables configuration of cameras to output 3.3V for external trigger circuitry. 