### PR TITLE
Color format pull request

### DIFF
--- a/spinnaker_camera_driver/src/SpinnakerCamera.cpp
+++ b/spinnaker_camera_driver/src/SpinnakerCamera.cpp
@@ -362,7 +362,8 @@ void SpinnakerCamera::grabImage(sensor_msgs::Image* image, const std::string& fr
         Spinnaker::GenICam::gcstring bayer_bg_str = "BayerBG";
 
         // if(isColor_ && bayer_format != NONE)
-        if (color_filter_ptr->GetCurrentEntry() != color_filter_ptr->GetEntryByName("None"))
+        if (color_filter_ptr->GetCurrentEntry() != color_filter_ptr->GetEntryByName("None") and
+            (bitsPerPixel == 16 or bitsPerPixel == 8))
         {
           if (bitsPerPixel == 16)
           {

--- a/spinnaker_camera_driver/src/gh3.cpp
+++ b/spinnaker_camera_driver/src/gh3.cpp
@@ -144,9 +144,9 @@ void Gh3::setNewConfiguration(const SpinnakerConfig& config, const uint32_t& lev
       setProperty(node_map_, "BalanceWhiteAuto", config.auto_white_balance);
       if (config.auto_white_balance.compare(std::string("Off")) == 0)
       {
-        setProperty(node_map_, "BalanceRatioSelector", "Blue");
+        setProperty(node_map_, "BalanceRatioSelector", std::string("Blue"));
         setProperty(node_map_, "BalanceRatio", static_cast<float>(config.white_balance_blue_ratio));
-        setProperty(node_map_, "BalanceRatioSelector", "Red");
+        setProperty(node_map_, "BalanceRatioSelector", std::string("Red"));
         setProperty(node_map_, "BalanceRatio", static_cast<float>(config.white_balance_red_ratio));
       }
     }


### PR DESCRIPTION
On selecting the parameter 'image_format_color_coding' to be 'RGB8' the camera file incorrectly decodes the color image. The color_filter_ptr node returned a non-none value (bayerRG) when the Grasshopper3 is used in RGB8 mode. That resulted in incorrect color decoding when using RGB8. Just need to check bit depth before considering bayer decoding.
Also cast "Red" and "Blue" to strings to call correct function.