### PR TITLE
Added compatability_fix workaround

### DIFF
--- a/spinnaker_camera_driver/cfg/Spinnaker.cfg
+++ b/spinnaker_camera_driver/cfg/Spinnaker.cfg
@@ -72,8 +72,7 @@ class SensorLevels:
   RECONFIGURE_STOP = 1
 
 gen = ParameterGenerator()
-
-
+gen.add("set_new_config",                        bool_t,      SensorLevels.RECONFIGURE_RUNNING,     "Enables the new config",                                                                           False)
 #       Name                                    Type          Reconfiguration level                  Description                                                                                        Default                     Min      Max
 gen.add("acquisition_frame_rate",                double_t,    SensorLevels.RECONFIGURE_RUNNING,     "User controlled acquisition frame rate in Hertz (frames per second).",                             10,                          0,        120)
 gen.add("acquisition_frame_rate_enable",         bool_t,      SensorLevels.RECONFIGURE_RUNNING,     "Enables manual (True) and automatic (False) control of the aquisition frame rate",                 False)
@@ -292,6 +291,8 @@ line_modes = gen.enum([gen.const("Input", str_t, "Input", ""),
 
 gen.add("line_mode", str_t, SensorLevels.RECONFIGURE_RUNNING, "Line Mode", "Input", edit_method = line_modes)
 
+# Camera 3.3V output parameters
+gen.add("enable_3V_output", bool_t, SensorLevels.RECONFIGURE_RUNNING, "Enable camera 3.3V output.",False)
 
 # Auto algorithm parameters
 gen.add("auto_exposure_roi_offset_x", int_t, SensorLevels.RECONFIGURE_RUNNING, "Auto exposure ROI X offset.", 0, 0, 65535)

--- a/spinnaker_camera_driver/src/camera.cpp
+++ b/spinnaker_camera_driver/src/camera.cpp
@@ -67,6 +67,7 @@ void Camera::setFrameRate(const float frame_rate)
 
 void Camera::setNewConfiguration(const SpinnakerConfig& config, const uint32_t& level)
 {
+  if(!config.set_new_config) return;
   try
   {
     if (level >= LEVEL_RECONFIGURE_STOP)
@@ -75,6 +76,10 @@ void Camera::setNewConfiguration(const SpinnakerConfig& config, const uint32_t& 
     setFrameRate(static_cast<float>(config.acquisition_frame_rate));
     // Set enable after frame rate encase its false
     setProperty(node_map_, "AcquisitionFrameRateEnable", config.acquisition_frame_rate_enable);
+
+    // Set 3.3V out put to support external circuitry
+    setProperty(node_map_, "V3_3Enable", config.enable_3V_output);
+
 
     // Set Trigger and Strobe Settings
     // NOTE: The trigger must be disabled (i.e. TriggerMode = "Off") in order to configure whether the source is


### PR DESCRIPTION
This is a workaround to run cameras that are working with Spinview BUT have compatibility issues with the driver. 
Added config.set_new_config = False