### PR TITLE
Explicit type to set BalanceRatioSelector

### DIFF
--- a/spinnaker_camera_driver/src/camera.cpp
+++ b/spinnaker_camera_driver/src/camera.cpp
@@ -150,9 +150,9 @@ void Camera::setNewConfiguration(const SpinnakerConfig& config, const uint32_t& 
       setProperty(node_map_, "BalanceWhiteAuto", config.auto_white_balance);
       if (config.auto_white_balance.compare(std::string("Off")) == 0)
       {
-        setProperty(node_map_, "BalanceRatioSelector", "Blue");
+        setProperty(node_map_, "BalanceRatioSelector", std::string("Blue"));
         setProperty(node_map_, "BalanceRatio", static_cast<float>(config.white_balance_blue_ratio));
-        setProperty(node_map_, "BalanceRatioSelector", "Red");
+        setProperty(node_map_, "BalanceRatioSelector", std::string("Red"));
         setProperty(node_map_, "BalanceRatio", static_cast<float>(config.white_balance_red_ratio));
       }
     }


### PR DESCRIPTION
I fixed the error to set assigned values of BalanceRatioSelector using this package. 

The same error was reported before. https://github.com/ros-drivers/flir_camera_driver/issues/30
This issue was temporally solved by setting Continuous or Once, but BalanceRatioSelector can not set the assigned values. 

◆Before
When this line calls "set property", 

https://github.com/ros-drivers/flir_camera_driver/blob/a79c509c6580ffed9ec61d7b4f514b4dc4283a95/spinnaker_camera_driver/src/camera.cpp#L153

it is supposed to call the following code.
https://github.com/ros-drivers/flir_camera_driver/blob/a79c509c6580ffed9ec61d7b4f514b4dc4283a95/spinnaker_camera_driver/include/spinnaker_camera_driver/set_property.h#L36

However, the result called the following instead of the above.
https://github.com/ros-drivers/flir_camera_driver/blob/a79c509c6580ffed9ec61d7b4f514b4dc4283a95/spinnaker_camera_driver/include/spinnaker_camera_driver/set_property.h#L162


◆After 
To call the setproperty having std::string in the third argument, I specified the type of "Blue" and "Red" as std::string.



◆Cause
The reason why the line called setpropety having bool is explained in the following page.
https://stackoverflow.com/questions/14770252/string-literal-matches-bool-overload-instead-of-stdstring




