### PR TITLE
Add readable check to SDK parameters

### DIFF
--- a/spinnaker_camera_driver/include/spinnaker_camera_driver/SpinnakerCamera.h
+++ b/spinnaker_camera_driver/include/spinnaker_camera_driver/SpinnakerCamera.h
@@ -162,6 +162,7 @@ public:
   void setGain(const float& gain);
   int getHeightMax();
   int getWidthMax();
+  bool readableProperty(const Spinnaker::GenICam::gcstring property_name);
   Spinnaker::GenApi::CNodePtr readProperty(const Spinnaker::GenICam::gcstring property_name);
 
   uint32_t getSerial()

--- a/spinnaker_camera_driver/include/spinnaker_camera_driver/camera.h
+++ b/spinnaker_camera_driver/include/spinnaker_camera_driver/camera.h
@@ -68,6 +68,8 @@ public:
 
   Spinnaker::GenApi::CNodePtr
   readProperty(const Spinnaker::GenICam::gcstring property_name);
+  bool
+  readableProperty(const Spinnaker::GenICam::gcstring property_name);
 
 protected:
   Spinnaker::GenApi::INodeMap* node_map_;

--- a/spinnaker_camera_driver/src/SpinnakerCamera.cpp
+++ b/spinnaker_camera_driver/src/SpinnakerCamera.cpp
@@ -118,6 +118,18 @@ int SpinnakerCamera::getWidthMax()
     return 0;
 }
 
+bool SpinnakerCamera::readableProperty(const Spinnaker::GenICam::gcstring property_name)
+{
+  if (camera_)
+  {
+    return camera_->readableProperty(property_name);
+  }
+  else
+  {
+    return 0;
+  }
+}
+
 Spinnaker::GenApi::CNodePtr SpinnakerCamera::readProperty(const Spinnaker::GenICam::gcstring property_name)
 {
   if (camera_)

--- a/spinnaker_camera_driver/src/camera.cpp
+++ b/spinnaker_camera_driver/src/camera.cpp
@@ -319,6 +319,12 @@ Spinnaker::GenApi::CNodePtr Camera::readProperty(const Spinnaker::GenICam::gcstr
   return ptr;
 }
 
+bool Camera::readableProperty(const Spinnaker::GenICam::gcstring property_name)
+{
+  Spinnaker::GenApi::CNodePtr ptr = node_map_->GetNode(property_name);
+  return Spinnaker::GenApi::IsAvailable(ptr) && Spinnaker::GenApi::IsReadable(ptr);
+}
+
 Camera::Camera(Spinnaker::GenApi::INodeMap* node_map)
 {
   node_map_ = node_map;

--- a/spinnaker_camera_driver/src/diagnostics.cpp
+++ b/spinnaker_camera_driver/src/diagnostics.cpp
@@ -199,6 +199,17 @@ void DiagnosticsManager::processDiagnostics(SpinnakerCamera* spinnaker)
 
   for (const std::string param : manufacturer_params_)
   {
+    // Check if Readable
+    if(!spinnaker->readableProperty(Spinnaker::GenICam::gcstring(param.c_str())))
+    {
+      diagnostic_msgs::KeyValue kv;
+      kv.key = param;
+      kv.value = "Property not Available and Readable";
+      diag_manufacture_info.values.push_back(kv);
+      continue;
+    }
+
+    // Write if Readable
     Spinnaker::GenApi::CStringPtr string_ptr = static_cast<Spinnaker::GenApi::CStringPtr>(
         spinnaker->readProperty(Spinnaker::GenICam::gcstring(param.c_str())));
 
@@ -213,6 +224,16 @@ void DiagnosticsManager::processDiagnostics(SpinnakerCamera* spinnaker)
   // Float based parameters
   for (const diagnostic_params<float>& param : float_params_)
   {
+    // Check if Readable
+    if(!spinnaker->readableProperty(Spinnaker::GenICam::gcstring(param.parameter_name)))
+    {
+      diagnostic_msgs::KeyValue kv;
+      kv.key = param.parameter_name;
+      kv.value = "Property not Available and Readable";
+      diag_manufacture_info.values.push_back(kv);
+      continue;
+    }
+
     Spinnaker::GenApi::CFloatPtr float_ptr =
         static_cast<Spinnaker::GenApi::CFloatPtr>(spinnaker->readProperty(param.parameter_name));
 
@@ -225,6 +246,16 @@ void DiagnosticsManager::processDiagnostics(SpinnakerCamera* spinnaker)
   // Int based parameters
   for (const diagnostic_params<int>& param : integer_params_)
   {
+    // Check if Readable
+    if(!spinnaker->readableProperty(Spinnaker::GenICam::gcstring(param.parameter_name)))
+    {
+      diagnostic_msgs::KeyValue kv;
+      kv.key = param.parameter_name;
+      kv.value = "Property not Available and Readable";
+      diag_manufacture_info.values.push_back(kv);
+      continue;
+    }
+
     Spinnaker::GenApi::CIntegerPtr integer_ptr =
         static_cast<Spinnaker::GenApi::CIntegerPtr>(spinnaker->readProperty(param.parameter_name));
 


### PR DESCRIPTION
added `readableProperty` method to `SpinnakerCamera` and `Camera` classes. 
This check returns whether property is readable to prevent calling `readProperty` and throwing an exception. 
In `Diagnostics.cpp`, `readableProperty` is used to publish warning message indicating that property is not accessible. 