### PR TITLE
Added parameter for device throughput limit

### DIFF
--- a/spinnaker_camera_driver/include/spinnaker_camera_driver/SpinnakerCamera.h
+++ b/spinnaker_camera_driver/include/spinnaker_camera_driver/SpinnakerCamera.h
@@ -130,6 +130,8 @@ public:
   */
   void stop();
 
+  void trigger();
+
   /*!
   * \brief Loads the raw data from the cameras buffer.
   *
@@ -166,6 +168,8 @@ public:
   int getWidthMax();
   bool readableProperty(const Spinnaker::GenICam::gcstring property_name);
   Spinnaker::GenApi::CNodePtr readProperty(const Spinnaker::GenICam::gcstring property_name);
+
+  void configureTrigger(bool enable, bool software);
 
   uint32_t getSerial()
   {

--- a/spinnaker_camera_driver/include/spinnaker_camera_driver/SpinnakerCamera.h
+++ b/spinnaker_camera_driver/include/spinnaker_camera_driver/SpinnakerCamera.h
@@ -159,6 +159,7 @@ public:
   * \param id serial number for the camera.  Should be something like 10491081.
   */
   void setDesiredCamera(const uint32_t& id);
+  void setThroughputLimit(const uint32_t& limit);
 
   void setGain(const float& gain);
   int getHeightMax();
@@ -198,6 +199,8 @@ private:
   unsigned int packet_size_;
   /// GigE packet delay:
   unsigned int packet_delay_;
+  /// GigE throughput limit:
+  unsigned int throughput_limit_;
 
   uint64_t timeout_;
 

--- a/spinnaker_camera_driver/include/spinnaker_camera_driver/camera.h
+++ b/spinnaker_camera_driver/include/spinnaker_camera_driver/camera.h
@@ -65,6 +65,7 @@ public:
   virtual void setGain(const float& gain);
   int getHeightMax();
   int getWidthMax();
+  void setThroughputLimit(const int& limit);
 
   Spinnaker::GenApi::CNodePtr
   readProperty(const Spinnaker::GenICam::gcstring property_name);

--- a/spinnaker_camera_driver/src/SpinnakerCamera.cpp
+++ b/spinnaker_camera_driver/src/SpinnakerCamera.cpp
@@ -303,6 +303,32 @@ void SpinnakerCamera::disconnect()
   }
 }
 
+void SpinnakerCamera::trigger()
+{
+  try
+  {
+    // Check if camera is connected
+    if (pCam_ && captureRunning_)
+    {
+        // Execute software trigger
+        Spinnaker::GenApi::CCommandPtr ptrSoftwareTriggerCommand = node_map_->GetNode("TriggerSoftware");
+        if (!Spinnaker::GenApi::IsAvailable(ptrSoftwareTriggerCommand) || 
+                !Spinnaker::GenApi::IsWritable(ptrSoftwareTriggerCommand))
+        {
+            throw std::runtime_error("[SpinnakerCamera::trigger] Unable to execute trigger ");
+        }
+
+        ptrSoftwareTriggerCommand->Execute();
+
+
+    }
+  }
+  catch (const Spinnaker::Exception& e)
+  {
+    throw std::runtime_error("[SpinnakerCamera::trigger] capture is not running ");
+  }
+}
+
 void SpinnakerCamera::start()
 {
   try
@@ -337,6 +363,138 @@ void SpinnakerCamera::stop()
     }
   }
 }
+
+// This function configures the camera to use a trigger. First, trigger mode is
+// set to off in order to select the trigger source. Once the trigger source
+// has been selected, trigger mode is then enabled, which has the camera
+// capture only a single image upon the execution of the chosen trigger.
+void SpinnakerCamera::configureTrigger(bool enable, bool software)
+{
+    try
+    {
+        //
+        // Ensure trigger mode off
+        //
+        // *** NOTES ***
+        // The trigger must be disabled in order to configure whether the source
+        // is software or hardware.
+        //
+        Spinnaker::GenApi::CEnumerationPtr ptrTriggerMode = node_map_->GetNode("TriggerMode");
+        if (!Spinnaker::GenApi::IsAvailable(ptrTriggerMode) || 
+                !Spinnaker::GenApi::IsReadable(ptrTriggerMode))
+        {
+            throw std::runtime_error("[SpinnakerCamera::configureTrigger] Unable to disable trigger mode (node retrieval)");
+        }
+
+        Spinnaker::GenApi::CEnumEntryPtr ptrTriggerModeOff = ptrTriggerMode->GetEntryByName("Off");
+        if (!Spinnaker::GenApi::IsAvailable(ptrTriggerModeOff) || 
+                !Spinnaker::GenApi::IsReadable(ptrTriggerModeOff))
+        {
+            throw std::runtime_error("[SpinnakerCamera::configureTrigger] Unable to disable trigger mode (enum entry retrieval)");
+        }
+
+        ptrTriggerMode->SetIntValue(ptrTriggerModeOff->GetValue());
+
+        if (!enable) {
+            ROS_INFO("Trigger mode disabled");
+            return;
+        }
+        ROS_INFO("Trigger mode disabled for configuration...");
+
+        //
+        // Set TriggerSelector to FrameStart
+        //
+        // *** NOTES ***
+        // For this example, the trigger selector should be set to frame start.
+        // This is the default for most cameras.
+        //
+        Spinnaker::GenApi::CEnumerationPtr ptrTriggerSelector = node_map_->GetNode("TriggerSelector");
+        if (!Spinnaker::GenApi::IsAvailable(ptrTriggerSelector) || 
+                !Spinnaker::GenApi::IsWritable(ptrTriggerSelector))
+        {
+            throw std::runtime_error("[SpinnakerCamera::configureTrigger] Unable to set trigger selector (node retrieval)");
+        }
+
+        Spinnaker::GenApi::CEnumEntryPtr ptrTriggerSelectorFrameStart = ptrTriggerSelector->GetEntryByName("FrameStart");
+        if (!Spinnaker::GenApi::IsAvailable(ptrTriggerSelectorFrameStart) || 
+                !Spinnaker::GenApi::IsReadable(ptrTriggerSelectorFrameStart))
+        {
+            throw std::runtime_error("[SpinnakerCamera::configureTrigger] Unable to set trigger selector (enum entry retrieval)");
+        }
+
+        ptrTriggerSelector->SetIntValue(ptrTriggerSelectorFrameStart->GetValue());
+
+        ROS_INFO("Trigger selector set to frame start...");
+
+        //
+        // Select trigger source
+        //
+        // *** NOTES ***
+        // The trigger source must be set to hardware or software while trigger
+        // mode is off.
+        //
+        Spinnaker::GenApi::CEnumerationPtr ptrTriggerSource = node_map_->GetNode("TriggerSource");
+        if (!Spinnaker::GenApi::IsAvailable(ptrTriggerSource) || 
+                !Spinnaker::GenApi::IsWritable(ptrTriggerSource))
+        {
+            throw std::runtime_error("[SpinnakerCamera::configureTrigger] Unable to set trigger mode (node retrieval)");
+        }
+
+        if (software) {
+            // Set trigger mode to software
+            Spinnaker::GenApi::CEnumEntryPtr ptrTriggerSourceSoftware = ptrTriggerSource->GetEntryByName("Software");
+            if (!Spinnaker::GenApi::IsAvailable(ptrTriggerSourceSoftware) || 
+                    !Spinnaker::GenApi::IsReadable(ptrTriggerSourceSoftware))
+            {
+                throw std::runtime_error("[SpinnakerCamera::configureTrigger] Unable to set trigger mode (enum entry retrieval)");
+            }
+
+            ptrTriggerSource->SetIntValue(ptrTriggerSourceSoftware->GetValue());
+
+            ROS_INFO("Trigger source set to software.");
+        } else {
+            // Set trigger mode to hardware ('Line0')
+            Spinnaker::GenApi::CEnumEntryPtr ptrTriggerSourceHardware = ptrTriggerSource->GetEntryByName("Line0");
+            if (!Spinnaker::GenApi::IsAvailable(ptrTriggerSourceHardware) || 
+                    !Spinnaker::GenApi::IsReadable(ptrTriggerSourceHardware))
+            {
+                throw std::runtime_error("[SpinnakerCamera::configureTrigger] Unable to set trigger mode (enum entry retrieval)");
+            }
+
+            ptrTriggerSource->SetIntValue(ptrTriggerSourceHardware->GetValue());
+
+            ROS_INFO("Trigger source set to hardware.");
+        }
+
+        //
+        // Turn trigger mode on
+        //
+        // *** LATER ***
+        // Once the appropriate trigger source has been set, turn trigger mode
+        // on in order to retrieve images using the trigger.
+        //
+
+        Spinnaker::GenApi::CEnumEntryPtr ptrTriggerModeOn = ptrTriggerMode->GetEntryByName("On");
+        if (!Spinnaker::GenApi::IsAvailable(ptrTriggerModeOn) || 
+                !Spinnaker::GenApi::IsReadable(ptrTriggerModeOn))
+        {
+            throw std::runtime_error("[SpinnakerCamera::configureTrigger] Unable to enable trigger mode (enum entry retrieval)");
+        }
+
+        ptrTriggerMode->SetIntValue(ptrTriggerModeOn->GetValue());
+
+        // NOTE: Blackfly and Flea3 GEV cameras need 1 second delay after trigger mode is turned on
+
+        ROS_INFO("Trigger mode turned back on...");
+    }
+    catch (Spinnaker::Exception& e)
+    {
+        throw std::runtime_error(std::string("[SpinnakerCamera::configureTrigger] ") + e.what());
+    }
+
+}
+
+
 
 void SpinnakerCamera::grabImage(sensor_msgs::Image* image, const std::string& frame_id)
 {
@@ -382,6 +540,9 @@ void SpinnakerCamera::grabImage(sensor_msgs::Image* image, const std::string& fr
       Spinnaker::GenICam::gcstring bayer_gr_str = "BayerGR";
       Spinnaker::GenICam::gcstring bayer_gb_str = "BayerGB";
       Spinnaker::GenICam::gcstring bayer_bg_str = "BayerBG";
+      ROS_WARN_STREAM_ONCE("[SpinnakerCamera::grabImage] camera "
+              << std::to_string(serial_)
+              << " pixel color filter is " << color_filter_str);
 
 
       // if(isColor_ && bayer_format != NONE)
@@ -481,6 +642,7 @@ void SpinnakerCamera::setTimeout(const double& timeout)
 {
   timeout_ = static_cast<uint64_t>(std::round(timeout * 1000));
 }
+
 void SpinnakerCamera::setDesiredCamera(const uint32_t& id)
 {
   serial_ = id;

--- a/spinnaker_camera_driver/src/SpinnakerCamera.cpp
+++ b/spinnaker_camera_driver/src/SpinnakerCamera.cpp
@@ -545,7 +545,6 @@ void SpinnakerCamera::grabImage(sensor_msgs::Image* image, const std::string& fr
               << " pixel color filter is " << color_filter_str);
 
 
-
       // if(isColor_ && bayer_format != NONE)
       if (color_filter_ptr->GetCurrentEntry() != color_filter_ptr->GetEntryByName("None"))
       {

--- a/spinnaker_camera_driver/src/SpinnakerCamera.cpp
+++ b/spinnaker_camera_driver/src/SpinnakerCamera.cpp
@@ -545,6 +545,7 @@ void SpinnakerCamera::grabImage(sensor_msgs::Image* image, const std::string& fr
               << " pixel color filter is " << color_filter_str);
 
 
+
       // if(isColor_ && bayer_format != NONE)
       if (color_filter_ptr->GetCurrentEntry() != color_filter_ptr->GetEntryByName("None"))
       {

--- a/spinnaker_camera_driver/src/SpinnakerCamera.cpp
+++ b/spinnaker_camera_driver/src/SpinnakerCamera.cpp
@@ -96,6 +96,12 @@ void SpinnakerCamera::setNewConfiguration(const spinnaker_camera_driver::Spinnak
   }
 }  // end setNewConfiguration
 
+void SpinnakerCamera::setThroughputLimit(const uint32_t& limit)
+{
+  if (camera_)
+    camera_->setThroughputLimit(limit);
+}
+
 void SpinnakerCamera::setGain(const float& gain)
 {
   if (camera_)
@@ -376,6 +382,7 @@ void SpinnakerCamera::grabImage(sensor_msgs::Image* image, const std::string& fr
       Spinnaker::GenICam::gcstring bayer_gr_str = "BayerGR";
       Spinnaker::GenICam::gcstring bayer_gb_str = "BayerGB";
       Spinnaker::GenICam::gcstring bayer_bg_str = "BayerBG";
+
 
       // if(isColor_ && bayer_format != NONE)
       if (color_filter_ptr->GetCurrentEntry() != color_filter_ptr->GetEntryByName("None"))

--- a/spinnaker_camera_driver/src/camera.cpp
+++ b/spinnaker_camera_driver/src/camera.cpp
@@ -242,6 +242,12 @@ void Camera::setGain(const float& gain)
   setProperty(node_map_, "Gain", static_cast<float>(gain));
 }
 
+void Camera::setThroughputLimit(const int& limit)
+{
+  setProperty(node_map_, "DeviceLinkThroughputLimit", limit);
+}
+
+
 /*
 void Camera::setGigEParameters(bool auto_packet_size, unsigned int packet_size, unsigned int packet_delay)
 {

--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -542,9 +542,11 @@ private:
               NODELET_DEBUG_ONCE("Setting timeout to: %f.", timeout);
               spinnaker_.setTimeout(timeout);
 
+#if 0
               NODELET_DEBUG_ONCE("Configuring trigger: %s %s", trigger_?"enabled":"disabled",
                       sw_trigger_?"software":"hardware");
               spinnaker_.configureTrigger(trigger_,sw_trigger_);
+#endif
 
             }
             catch (const std::runtime_error& e)

--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -302,6 +302,7 @@ private:
     pnh.param<int>("packet_size", packet_size_, 1400);
     pnh.param<bool>("auto_packet_size", auto_packet_size_, true);
     pnh.param<int>("packet_delay", packet_delay_, 4000);
+    pnh.param<int>("throughput_limit", throughput_limit_, 125000000);
 
     // TODO(mhosmar):  Set GigE parameters:
     // spinnaker_.setGigEParameters(auto_packet_size_, packet_size_, packet_delay_);
@@ -518,6 +519,7 @@ private:
             NODELET_DEBUG("Connected to camera.");
 
             // Set last configuration, forcing the reconfigure level to stop
+            spinnaker_.setThroughputLimit(throughput_limit_);
             spinnaker_.setNewConfiguration(config_, SpinnakerCamera::LEVEL_RECONFIGURE_STOP);
 
             // Set the timeout for grabbing images.
@@ -719,6 +721,8 @@ private:
   int packet_size_;
   /// GigE packet delay:
   int packet_delay_;
+  /// GigE throughput limit:
+  int throughput_limit_;
 
   /// Configuration:
   spinnaker_camera_driver::SpinnakerConfig config_;

--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -303,9 +303,12 @@ private:
     pnh.param<bool>("auto_packet_size", auto_packet_size_, true);
     pnh.param<int>("packet_delay", packet_delay_, 4000);
     pnh.param<int>("throughput_limit", throughput_limit_, 125000000);
+<<<<<<< HEAD
     pnh.param<bool>("trigger", trigger_, false);
     pnh.param<bool>("sw_trigger", sw_trigger_, false);
     pnh.param<double>("max_trigger_delay", max_trigger_delay_, 0.2);
+=======
+>>>>>>> Added parameter for device throughput limit
 
     // TODO(mhosmar):  Set GigE parameters:
     // spinnaker_.setGigEParameters(auto_packet_size_, packet_size_, packet_delay_);
@@ -529,7 +532,10 @@ private:
             NODELET_DEBUG("Connected to camera.");
 
             // Set last configuration, forcing the reconfigure level to stop
+<<<<<<< HEAD
             ROS_INFO("Nodelet: throughput limit to %d",throughput_limit_);
+=======
+>>>>>>> Added parameter for device throughput limit
             spinnaker_.setThroughputLimit(throughput_limit_);
             spinnaker_.setNewConfiguration(config_, SpinnakerCamera::LEVEL_RECONFIGURE_STOP);
 

--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -303,12 +303,9 @@ private:
     pnh.param<bool>("auto_packet_size", auto_packet_size_, true);
     pnh.param<int>("packet_delay", packet_delay_, 4000);
     pnh.param<int>("throughput_limit", throughput_limit_, 125000000);
-<<<<<<< HEAD
-    pnh.param<bool>("trigger", trigger_, false);
+    pnh.param<bool>("en_trigger", trigger_, false);
     pnh.param<bool>("sw_trigger", sw_trigger_, false);
     pnh.param<double>("max_trigger_delay", max_trigger_delay_, 0.2);
-=======
->>>>>>> Added parameter for device throughput limit
 
     // TODO(mhosmar):  Set GigE parameters:
     // spinnaker_.setGigEParameters(auto_packet_size_, packet_size_, packet_delay_);
@@ -532,10 +529,7 @@ private:
             NODELET_DEBUG("Connected to camera.");
 
             // Set last configuration, forcing the reconfigure level to stop
-<<<<<<< HEAD
             ROS_INFO("Nodelet: throughput limit to %d",throughput_limit_);
-=======
->>>>>>> Added parameter for device throughput limit
             spinnaker_.setThroughputLimit(throughput_limit_);
             spinnaker_.setNewConfiguration(config_, SpinnakerCamera::LEVEL_RECONFIGURE_STOP);
 

--- a/url.txt
+++ b/url.txt
@@ -1,0 +1,1 @@
+https://www.flir.com/support-center/iis/machine-vision/knowledge-base/lost-ethernet-data-packets-on-linux-systems/


### PR DESCRIPTION
Hello, I was testing this package with multiple cameras on a gigabit switch and I could not get more than one camera streaming on the bus (Blackfly camera) without explicitly setting the device throughput limit. I had the same problem using the spinnaker app, so I validated it there before adding the parameters to the ros application. 

I can now stream 4x6MP cameras in color at 5Hz, using a 30'000'000 throughput limit for each camera (reaching close to the 125'000'000) theoretical limit of the bus. 