### PR TITLE
use cmake find_program to detect lsb_release

### DIFF
--- a/spinnaker_camera_driver/cmake/DownloadSpinnaker.cmake
+++ b/spinnaker_camera_driver/cmake/DownloadSpinnaker.cmake
@@ -17,8 +17,9 @@ function(download_spinnaker FLIR_LIB_VAR FLIR_INCLUDE_DIR_VAR)
     message(FATAL_ERROR "Downloading libSpinnaker for non-linux systems not supported")
   endif()
 
+  find_program(LSB_RELEASE_EXEC lsb_release REQUIRED)
   execute_process(
-    COMMAND lsb_release -cs
+    COMMAND ${LSB_RELEASE_EXEC} -cs
     OUTPUT_VARIABLE OS_CODE_NAME
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 


### PR DESCRIPTION
Use cmake to find lsb_release in hopes that this fixes the build failures on ROS's build servers.
This PR attempts to address issue #115 