### PR TITLE
add dependencies for spinnaker download

### DIFF
--- a/spinnaker_camera_driver/package.xml
+++ b/spinnaker_camera_driver/package.xml
@@ -9,6 +9,12 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>lsb-release</build_depend>  <!-- to find OS release info -->
+  <build_depend>curl</build_depend>  <!-- to get ca-certificates for downloading Spinnaker -->
+  <build_depend>dpkg</build_depend>  <!-- for unpacking Spinnaker debs  -->
+  
+  <depend>libusb-1.0-dev</depend> <!-- spinnaker dependency -->
+
   <depend>camera_info_manager</depend>
   <depend>flir_camera_msgs</depend>
   <depend>image_transport</depend>

--- a/spinnaker_camera_driver/package.xml
+++ b/spinnaker_camera_driver/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>lsb-release</build_depend>  <!-- to find OS release info -->
+  <build_depend>python3-distro</build_depend>  <!-- to get lsb_release for downloading Spinnaker -->
   <build_depend>curl</build_depend>  <!-- to get ca-certificates for downloading Spinnaker -->
   <build_depend>dpkg</build_depend>  <!-- for unpacking Spinnaker debs  -->
   


### PR DESCRIPTION
The ``lsb_release`` seems to be missing on the build servers. This PR adds a dependency on the ``lsb-release`` package which in theory should make sure the command is available at build time.
This PR also adds other Spinnaker download and runtime dependencies gleaned from the noetic-devel branch.