### PR TITLE
install spinnaker libraries in spinnaker_camera_driver dir

### DIFF
--- a/spinnaker_camera_driver/CMakeLists.txt
+++ b/spinnaker_camera_driver/CMakeLists.txt
@@ -43,11 +43,13 @@ find_package(SPINNAKER QUIET)
 message(STATUS
   "Found variable: ${SPINNAKER_FOUND} at ${SPINNAKER_LIBRARIES} and ${SPINNAKER_INCLUDE_DIRS}")
 
+set(SPINNAKER_WAS_DOWNLOADED FALSE)
 if(NOT SPINNAKER_FOUND)
   message(STATUS "spinnaker not found")
   message(STATUS "libSpinnaker not found in system library path")
   include(cmake/DownloadSpinnaker.cmake)
   download_spinnaker(SPINNAKER_LIBRARIES SPINNAKER_INCLUDE_DIRS)
+  set(SPINNAKER_WAS_DOWNLOADED TRUE)
 endif()
 
 message(STATUS "libSpinnaker library location: ${SPINNAKER_LIBRARIES}")
@@ -116,7 +118,6 @@ target_include_directories(camera_driver_node
 
 target_include_directories(camera_driver PRIVATE include)
 
-
 # the node must go into the project specific lib directory or else
 # the launch file will not find it
 
@@ -141,6 +142,13 @@ install(DIRECTORY
   launch
   DESTINATION share/${PROJECT_NAME}/
 )
+
+if(SPINNAKER_WAS_DOWNLOADED)
+  set(SPINNAKER_BUILD_SUBDIR "opt/spinnaker/lib")
+  set(SPINNAKER_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/${SPINNAKER_BUILD_SUBDIR}")
+  message(STATUS "installing spinnaker libraries from ${SPINNAKER_BUILD_DIR}")
+  install(DIRECTORY  "${SPINNAKER_BUILD_DIR}" DESTINATION ${CMAKE_INSTALL_PREFIX})
+endif()
 
 if(BUILD_TESTING)
   find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
This PR is trying to fix build issues on the ROS2 build farms (issue #117)
```
02:10:53 dpkg-shlibdeps: warning: can't extract name and version from library name 'librcutils.so'
02:10:53 dpkg-shlibdeps: error: cannot find library libSpinnaker.so.3 needed by debian/ros-humble-spinnaker-camera-driver/opt/ros/humble/lib/libcamera_driver.so (ELF format: 'elf64-x86-64' abi: '0201003e00000000'; RPATH: '')
02:10:53 dpkg-shlibdeps: warning: can't extract name and version from library name 'libcamera_info_manager.so'
```
The driver builds correctly, but the packaging fails. One possible problem could be that  libSpinnaker.so.3 never gets copied from build to install directory.
This PR installs the Spinnaker libraries under the ROS spinnaker_camera_driver binary dir.
In my development environment I can run the driver now even after deleting the "build" directory. Let's see if the packaging finds the libraries now, too.
