### PR TITLE
add ffmpeg depency to fix build failures on ROS farm

### DIFF
--- a/spinnaker_camera_driver/package.xml
+++ b/spinnaker_camera_driver/package.xml
@@ -14,6 +14,7 @@
   <build_depend>dpkg</build_depend>  <!-- for unpacking Spinnaker debs  -->
 
   <depend>libusb-1.0-dev</depend> <!-- spinnaker dependency -->
+  <depend>ffmpeg</depend> <!-- spinnaker dependency -->
 
   <depend>yaml-cpp</depend> <!-- parameter definition file parsing -->
 


### PR DESCRIPTION
This PR may help the packaging errors on the ROS build farm. See issue #115 
```
17:54:38 dpkg-shlibdeps: error: cannot find library libswscale.so.5 needed by debian/ros-humble-spinnaker-camera-driver/opt/ros/humble/lib/libSpinVideo.so.3.1.0.79 (ELF format: 'elf64-x86-64' abi: '0201003e00000000'; RPATH: '')
17:54:38 dpkg-shlibdeps: error: cannot find library libavcodec.so.58 needed by debian/ros-humble-spinnaker-camera-driver/opt/ros/humble/lib/libSpinVideo.so.3.1.0.79 (ELF format: 'elf64-x86-64' abi: '0201003e00000000'; RPATH: '')
17:54:38 dpkg-shlibdeps: error: cannot find library libavutil.so.56 needed by debian/ros-humble-spinnaker-camera-driver/opt/ros/humble/lib/libSpinVideo.so.3.1.0.79 (ELF format: 'elf64-x86-64' abi: '0201003e00000000'; RPATH: '')
17:54:38 dpkg-shlibdeps: error: cannot find library libavformat.so.58 needed by debian/ros-humble-spinnaker-camera-driver/opt/ros/humble/lib/libSpinVideo.so.3.1.0.79 (ELF format: 'elf64-x86-64' abi: '0201003e00000000'; RPATH: '')
```