### PR TITLE
resurrect building when Spinnaker SDK is present, build on ubuntu 20.04

### DIFF
--- a/spinnaker_camera_driver/CMakeLists.txt
+++ b/spinnaker_camera_driver/CMakeLists.txt
@@ -38,7 +38,10 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 # the Point Grey EULA prohibits redistributing the headers or the packages which
 # contains them. We work around this by downloading the archive directly from
 # their website during this step in the build process.
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+
+# Spinnaker does not provide a cmake discovery mechanism so we
+# provide a find script in the cmake path
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 find_package(SPINNAKER QUIET)
 message(STATUS
   "Found variable: ${SPINNAKER_FOUND} at ${SPINNAKER_LIBRARIES} and ${SPINNAKER_INCLUDE_DIRS}")
@@ -50,6 +53,8 @@ if(NOT SPINNAKER_FOUND)
   include(cmake/DownloadSpinnaker.cmake)
   download_spinnaker(SPINNAKER_LIBRARIES SPINNAKER_INCLUDE_DIRS)
   set(SPINNAKER_WAS_DOWNLOADED TRUE)
+else()
+  message(STATUS "spinnaker SDK found installed")
 endif()
 
 message(STATUS "libSpinnaker library location: ${SPINNAKER_LIBRARIES}")

--- a/spinnaker_camera_driver/README.md
+++ b/spinnaker_camera_driver/README.md
@@ -34,8 +34,8 @@ installation the USB kernel configuration is modified as needed and
 suitable access permissions are granted (udev rules).
 If you choose to *not* use the Spinnaker SDK, you must perform the
 [required setup steps manually](docs/linux_setup_flir.md).
-Without these setup steps, *the ROS driver will not detect the
-camera*.
+Without these setup steps,
+*the ROS driver will not detect the camera*.
 So you must either install the Spinnaker SDK (which also gives you the
 useful ``spinview`` tool), or follow the manual setup steps mentioned earlier.
 
@@ -62,7 +62,7 @@ Create a workspace (``~/ws``), clone this repo:
 ```
 mkdir -p ~/ws/src
 cd ~/ws/src
-git clone https://github.com/ros-drivers/flir_camera_driver
+git clone --branch humble-devel https://github.com/ros-drivers/flir_camera_driver
 cd ..
 ```
 

--- a/spinnaker_camera_driver/cmake/FindSPINNAKER.cmake
+++ b/spinnaker_camera_driver/cmake/FindSPINNAKER.cmake
@@ -32,9 +32,6 @@ if( EXISTS "$ENV{SPINNAKER_ROOT_DIR}" )
   set( SPINNAKER_ROOT_DIR "${SPINNAKER_ROOT_DIR}" CACHE PATH "Prefix for Spinnaker installation." )
 endif()
 
-cmake_path(SET PATH2 "${CMAKE_CURRENT_BINARY_DIR}")
-cmake_path(GET PATH2 PARENT_PATH PARENTDIR)
-
 find_path(SPINNAKER_INCLUDE_DIRS
   NAMES Spinnaker.h
   HINTS
@@ -46,7 +43,7 @@ find_path(SPINNAKER_INCLUDE_DIRS
 )
 
 find_library(SPINNAKER_LIBRARIES
-  NAMES SPINNAKER
+  NAMES Spinnaker
   HINTS
   ${SPINNAKER_ROOT_DIR}/lib
   /opt/spinnaker/lib

--- a/spinnaker_camera_driver/src/camera_driver.cpp
+++ b/spinnaker_camera_driver/src/camera_driver.cpp
@@ -204,7 +204,8 @@ bool CameraDriver::readParameterDefinitionFile()
   RCLCPP_INFO_STREAM(get_logger(), "parameter definitions file: " << parameterFile_);
   YAML::Node yamlFile = YAML::LoadFile(parameterFile_);
   if (yamlFile.IsNull()) {
-    throw YAML::BadFile(parameterFile_);
+    RCLCPP_ERROR_STREAM(get_logger(), "cannot open file: " << parameterFile_);
+    return (false);
   }
   if (!yamlFile["parameters"].IsSequence()) {
     RCLCPP_ERROR_STREAM(get_logger(), "parameter definitions lists no parameters!");


### PR DESCRIPTION
Some bugs had crept into the cmake files that prevented the driver from building when the SDK is in fact installed (rather than downloaded).
This PR fixes that, as well as glitches in the documentation. The PR also removes usage of a late yaml-cpp feature that prevents building on Ubuntu 20.04.
