### PR TITLE
use correct file name when downloading spinnaker from clearpath web site

### DIFF
--- a/spinnaker_camera_driver/cmake/download_spinnaker
+++ b/spinnaker_camera_driver/cmake/download_spinnaker
@@ -40,7 +40,7 @@ import glob
 logging.basicConfig(level=logging.INFO)
 
 URL_TEMPLATE = URL_TEMPLATES = {
-    'deb': 'https://packages.clearpathrobotics.com/stable/flir/Spinnaker/Ubuntu{version}/spinnaker-3.1.0.79-{arch}-pkg.tar.gz',
+    'deb': 'https://packages.clearpathrobotics.com/stable/flir/Spinnaker/Ubuntu{version}/spinnaker-3.1.0.79-Ubuntu{version}-{arch}-pkg.tar.gz',
     'src': None         # if we ever have non-deb archives that require manual extraction, those package URLS will go here.
 }
 


### PR DESCRIPTION
This PR attempts to fix the broken build for ARM64 by adding the "Ubuntu22.04" string into the download name. This should match the file names on Clearpath's servers which look like this.
```
spinnaker-3.1.0.79-amd64-pkg.tar.gz
spinnaker-3.1.0.79-Ubuntu22.04-amd64-pkg.tar.gz
spinnaker-3.1.0.79-Ubuntu22.04-arm64-pkg.tar.gz
spinnaker-3.1.0.79-Ubuntu22.04-armhf-pkg.tar.gz
```
This PR cannot be tested because I don't have arm64. We'll have to see if it builds on the ROS build farms.
