### PR TITLE
reformat source to satisfy linter

### DIFF
--- a/flir_camera_description/launch/demo.launch.py
+++ b/flir_camera_description/launch/demo.launch.py
@@ -76,8 +76,8 @@ def generate_launch_description():
     )
 
     world_tf_publisher = Node(
-        package="tf2_ros",
-        executable="static_transform_publisher",
+        package='tf2_ros',
+        executable='static_transform_publisher',
         arguments=['--x', '0', '--y', '0', '--z', '1', '--yaw', '0',
                    '--pitch', '0', '--roll', '0',
                    '--frame-id', 'world', '--child-frame-id', 'camera_frame'])

--- a/spinnaker_camera_driver/CMakeLists.txt
+++ b/spinnaker_camera_driver/CMakeLists.txt
@@ -166,7 +166,7 @@ if(BUILD_TESTING)
   find_package(ament_cmake_clang_format REQUIRED)
   find_package(ament_cmake_xmllint REQUIRED)
 
-  ament_copyright(EXCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/cmake/TargetArch.cmake)
+  ament_copyright()
   ament_cppcheck(LANGUAGE c++)
   ament_cpplint(FILTERS "-build/include,-runtime/indentation_namespace")
   ament_flake8()

--- a/spinnaker_camera_driver/cmake/TargetArch.cmake
+++ b/spinnaker_camera_driver/cmake/TargetArch.cmake
@@ -1,21 +1,33 @@
 # Source: https://raw.github.com/petroules/solar-cmake/master/TargetArch.cmake
 #
-#  Copyright 2012, Petroules Corporation, All rights reserved.
+#  Copyright 2012, Petroules Corporation
+# All rights reserved.
 #
-# Redistribution and use in source and binary forms, with or without modification, are permitted provided
-# that the following conditions are met:
+# Software License Agreement (BSD 2-Clause Simplified License)
 #
-# Redistributions of source code must retain the above copyright notice, this list of conditions and the
-# following disclaimer. Redistributions in binary form must reproduce the above copyright notice, this list
-# of conditions and the following disclaimer in the documentation and/or other materials provided with the
-# distribution. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
-# OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
-# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
-# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 
 # Based on the Qt 5 processor detection code, so should be very accurate
 # https://qt.gitorious.org/qt/qtbase/blobs/master/src/corelib/global/qprocessordetection.h

--- a/spinnaker_camera_driver/launch/driver_node.launch.py
+++ b/spinnaker_camera_driver/launch/driver_node.launch.py
@@ -15,14 +15,15 @@
 #
 #
 
-from launch_ros.substitutions import FindPackageShare
-from launch_ros.actions import Node
-
-from launch.substitutions import LaunchConfiguration as LaunchConfig
-from launch.substitutions import PathJoinSubstitution
+from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument as LaunchArg
 from launch.actions import OpaqueFunction
-from launch import LaunchDescription
+from launch.substitutions import LaunchConfiguration as LaunchConfig
+from launch.substitutions import PathJoinSubstitution
+
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
 
 example_parameters = {
     'blackfly_s': {

--- a/spinnaker_camera_driver/launch/stereo_synced.launch.py
+++ b/spinnaker_camera_driver/launch/stereo_synced.launch.py
@@ -15,14 +15,16 @@
 #
 #
 
-from launch_ros.actions import ComposableNodeContainer
-from launch_ros.substitutions import FindPackageShare
-from launch_ros.descriptions import ComposableNode
-from launch.substitutions import LaunchConfiguration as LaunchConfig
-from launch.substitutions import PathJoinSubstitution
+from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument as LaunchArg
 from launch.actions import OpaqueFunction
-from launch import LaunchDescription
+from launch.substitutions import LaunchConfiguration as LaunchConfig
+from launch.substitutions import PathJoinSubstitution
+
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
+from launch_ros.substitutions import FindPackageShare
+
 
 camera_params = {
     'debug': False,

--- a/spinnaker_camera_driver/package.xml
+++ b/spinnaker_camera_driver/package.xml
@@ -6,6 +6,7 @@
   <description>ROS2 driver for flir spinnaker sdk</description>
   <maintainer email="bernd.pfrommer@gmail.com">Bernd Pfrommer</maintainer>
   <license>Apache-2</license>
+  <license>BSD</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 


### PR DESCRIPTION
- reformat copyright notice to make linter happy
- reformat python launch files to get order of includes correctly
The reformatting was necessary after I installed ros-humble-ament-cmake-include-directories on my machine.
