### PR TITLE
Add Binning Parameter

### DIFF
--- a/spinnaker_camera_driver/config/blackfly_s.yaml
+++ b/spinnaker_camera_driver/config/blackfly_s.yaml
@@ -15,6 +15,12 @@ parameters:
     # Some formats are e.g. "Mono8", "BayerRG8", "BGR8", "BayerRG16"
     # default is "BayerRG8"
     node: ImageFormatControl/PixelFormat
+  - name: binning_x
+    type: int
+    node: ImageFormatControl/BinningHorizontal
+  - name: binning_y
+    type: int
+    node: ImageFormatControl/BinningVertical
   - name: image_width
     type: int
     node: ImageFormatControl/Width
@@ -27,6 +33,7 @@ parameters:
   - name: offset_y
     type: int
     node: ImageFormatControl/OffsetY
+
   #
   # -------- analog control
   #
@@ -104,7 +111,7 @@ parameters:
     # "LogicBlock<0,1>
     node: AcquisitionControl/TriggerSource
   - name: trigger_delay
-    # value >= 9 
+    # value >= 9
     type: float
     node: AcquisitionControl/TriggerDelay
   - name: trigger_overlap

--- a/spinnaker_camera_driver/launch/driver_node.launch.py
+++ b/spinnaker_camera_driver/launch/driver_node.launch.py
@@ -43,6 +43,8 @@ example_parameters = {
         # 'image_height': 1080,
         # 'offset_x': 16,
         # 'offset_y': 0,
+        # 'binning_x': 1,
+        # 'binning_y': 1,
         'frame_rate_auto': 'Off',
         'frame_rate': 40.0,
         'frame_rate_enable': True,


### PR DESCRIPTION
Cropping the image is the only way to currently reduce the resolution of the camera. 

By using binning we can reduce the resolution of most Spinnaker based cameras by at least half, improving performance of the node and other image transport layers. 