### PR TITLE
Update FLIR_LIB_VAR in DownloadSpinnaker.cmake

### DIFF
--- a/spinnaker_camera_driver/cmake/DownloadSpinnaker.cmake
+++ b/spinnaker_camera_driver/cmake/DownloadSpinnaker.cmake
@@ -16,6 +16,6 @@ function(download_spinnaker FLIR_LIB_VAR FLIR_INCLUDE_DIR_VAR)
   message(STATUS "Running download_spinnaker script with arguments: ${FLIR_ARCH} ${FLIR_DIR} ${OS_CODE_NAME}")
   execute_process(
     COMMAND ${DOWNLOAD_SCRIPT} ${FLIR_ARCH} "${FLIR_DIR}" ${OS_CODE_NAME})
-  set(${FLIR_LIB_VAR} "${CMAKE_BINARY_DIR}/usr/lib/libSpinnaker.so" PARENT_SCOPE)
+  set(${FLIR_LIB_VAR} "${CMAKE_BINARY_DIR}/opt/spinnaker/lib/libSpinnaker.so" PARENT_SCOPE)
   set(${FLIR_INCLUDE_DIR_VAR} "${CMAKE_BINARY_DIR}/opt/spinnaker/include/" PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
Fix to (catkin_make): *** No rule to make target 'usr/lib/libSpinnaker.so', needed by '/devel/lib/libSpinnakerCameraLib.so'.