### PR TITLE
avoid searching ROS path for library

### DIFF
--- a/spinnaker_camera_driver/cmake/FindSPINNAKER.cmake
+++ b/spinnaker_camera_driver/cmake/FindSPINNAKER.cmake
@@ -49,6 +49,7 @@ find_library(SPINNAKER_LIBRARIES
   /usr/lib/
   /usr/local/lib
   PATH_SUFFIXES Release Debug
+  NO_DEFAULT_PATH  # else it will find ROS system spinnaker libraries first
 )
 
 set(SPINNAKER_INCLUDE_DIRS ${SPINNAKER_INCLUDE_DIRS})


### PR DESCRIPTION
This PR fixes nasty problems when compiling from source against Spinnaker 4.0. Without this fix, the libraries are picked up from /opt/ros/${ROS_DISTRO} whereas the include files are found in /opt/spinnaker/include. Unfortunately there are no compile time errors, but an exception is thrown when registering for image events.
