### PR TITLE
PR from Iago Gomes to work around issues with multiple interfaces

### DIFF
--- a/spinnaker_camera_driver/CMakeLists.txt
+++ b/spinnaker_camera_driver/CMakeLists.txt
@@ -65,6 +65,16 @@ message(STATUS "libSpinnaker include location: ${SPINNAKER_INCLUDE_DIRS}")
 
 find_package(SPINNAKER REQUIRED)
 
+# special case the older Spinnaker API
+if(DEFINED ENV{ROS_DISTRO})
+  if($ENV{ROS_DISTRO} STREQUAL "foxy" OR
+      $ENV{ROS_DISTRO} STREQUAL "galactic")
+    add_definitions(-DUSE_OLD_SPINNAKER_API)
+  endif()
+else()
+  message(FATAL_ERROR "ROS_DISTRO environment variable is not set!")
+endif()
+
 include_directories(SYSTEM
   ${SPINNAKER_INCLUDE_DIRS})
 
@@ -78,7 +88,6 @@ set(ROS_DEPENDENCIES
   "camera_info_manager"
   "image_transport"
   "flir_camera_msgs")
-
 
 # find dependencies
 find_package(ament_cmake REQUIRED)

--- a/spinnaker_camera_driver/package.xml
+++ b/spinnaker_camera_driver/package.xml
@@ -16,6 +16,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ros_environment</buildtool_depend> <!-- ROS_VERSION + ROS_DISTRO -->
 
   <build_depend>python3-distro</build_depend>  <!-- to get lsb_release for downloading Spinnaker -->
   <build_depend>curl</build_depend>  <!-- to get ca-certificates for downloading Spinnaker -->

--- a/spinnaker_camera_driver/src/spinnaker_wrapper_impl.cpp
+++ b/spinnaker_camera_driver/src/spinnaker_wrapper_impl.cpp
@@ -105,6 +105,12 @@ SpinnakerWrapperImpl::SpinnakerWrapperImpl()
 
 void SpinnakerWrapperImpl::refreshCameraList()
 {
+#ifdef USE_OLD_SPINNAKER_API
+  cameraList_ = system_->GetCameras();
+  for (size_t cam_idx = 0; cam_idx < cameraList_.GetSize(); cam_idx++) {
+    const auto cam = cameraList_[cam_idx];
+  }
+#else
   cameraList_.Clear();
 
   Spinnaker::InterfaceList interfaceList = system_->GetInterfaces();
@@ -150,6 +156,7 @@ void SpinnakerWrapperImpl::refreshCameraList()
   }      // end for interfaceList
 
   interfaceList.Clear();
+#endif
 }
 
 SpinnakerWrapperImpl::~SpinnakerWrapperImpl()

--- a/spinnaker_camera_driver/src/spinnaker_wrapper_impl.hpp
+++ b/spinnaker_camera_driver/src/spinnaker_wrapper_impl.hpp
@@ -21,6 +21,7 @@
 
 #include <memory>
 #include <mutex>
+#include <rclcpp/rclcpp.hpp>
 #include <spinnaker_camera_driver/image.hpp>
 #include <spinnaker_camera_driver/spinnaker_wrapper.hpp>
 #include <string>
@@ -66,6 +67,8 @@ private:
   void setPixelFormat(const std::string & pixFmt);
   bool setInINodeMap(double f, const std::string & field, double * fret);
   void monitorStatus();
+
+  rclcpp::Logger get_logger() { return rclcpp::get_logger("Spinnaker Wrapper"); }
 
   // ----- variables --
   Spinnaker::SystemPtr system_;


### PR DESCRIPTION
This pull request changes the refreshCameraList function under spinnaker_wrapper_impl.cpp to search for cameras in all network interfaces.

modified files:
-- spinnaker_camera_driver/src/spinnaker_wrapper_impl.cpp
-- spinnaker_camera_driver/src/spinnaker_wrapper_impl.hpp

Originally filed as PR #194 