### PR TITLE
only access camera with correct serial

### DIFF
--- a/spinnaker_camera_driver/CMakeLists.txt
+++ b/spinnaker_camera_driver/CMakeLists.txt
@@ -65,16 +65,6 @@ message(STATUS "libSpinnaker include location: ${SPINNAKER_INCLUDE_DIRS}")
 
 find_package(SPINNAKER REQUIRED)
 
-# special case the older Spinnaker API
-if(DEFINED ENV{ROS_DISTRO})
-  if($ENV{ROS_DISTRO} STREQUAL "foxy" OR
-      $ENV{ROS_DISTRO} STREQUAL "galactic")
-    add_definitions(-DUSE_OLD_SPINNAKER_API)
-  endif()
-else()
-  message(FATAL_ERROR "ROS_DISTRO environment variable is not set!")
-endif()
-
 include_directories(SYSTEM
   ${SPINNAKER_INCLUDE_DIRS})
 


### PR DESCRIPTION
This PR addresses issue #201  related to PR #195.
The hope is that initializing only the camera with the proper serial number will not upset other FLIR cameras served by a different driver.

Could @iag0g0mes please test if this works correctly for your case of multiple interfaces?
