### PR TITLE
support brightness computation for all bayer image types

### DIFF
--- a/spinnaker_camera_driver/include/spinnaker_camera_driver/pixel_format.hpp
+++ b/spinnaker_camera_driver/include/spinnaker_camera_driver/pixel_format.hpp
@@ -56,6 +56,7 @@ enum PixelFormat {
 };
 std::string to_string(PixelFormat f);
 PixelFormat from_nodemap_string(const std::string pixFmt);
+bool is_bayer(PixelFormat f);
 }  // namespace pixel_format
 }  // namespace spinnaker_camera_driver
 #endif  // SPINNAKER_CAMERA_DRIVER__PIXEL_FORMAT_HPP_

--- a/spinnaker_camera_driver/src/pixel_format.cpp
+++ b/spinnaker_camera_driver/src/pixel_format.cpp
@@ -16,6 +16,7 @@
 #include <spinnaker_camera_driver/pixel_format.hpp>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace spinnaker_camera_driver
 {
@@ -81,11 +82,17 @@ static const std::unordered_map<std::string, PixelFormat> string_2_fmt{
    {"BGR8", BGR8},
    {"BGRa8", BGRa8}}};
 
+static const std::unordered_set<PixelFormat> bayer_formats{
+  BayerRG8, BayerRG10p, BayerRG10Packed, BayerRG12p, BayerRG12Packed, BayerRG16,
+  BayerGR8, BayerGR16,  BayerGB8,        BayerGB16,  BayerBG8,        BayerBG16};
+
 PixelFormat from_nodemap_string(const std::string pixFmt)
 {
   auto it = string_2_fmt.find(pixFmt);
   return (it == string_2_fmt.end() ? INVALID : it->second);
 }
+
+bool is_bayer(const PixelFormat f) { return (bayer_formats.find(f) != bayer_formats.end()); }
 
 std::string to_string(PixelFormat f)
 {

--- a/spinnaker_camera_driver/src/spinnaker_wrapper_impl.cpp
+++ b/spinnaker_camera_driver/src/spinnaker_wrapper_impl.cpp
@@ -286,7 +286,7 @@ static int int_ceil(size_t x, int y)
 static int16_t compute_brightness(
   pixel_format::PixelFormat pf, const uint8_t * data, size_t w, size_t h, size_t stride, int skip)
 {
-  if (pf != pixel_format::BayerRG8) {
+  if (!pixel_format::is_bayer(pf)) {
     return (0);
   }
   const uint64_t cnt = int_ceil(w, skip) * int_ceil(h, skip);


### PR DESCRIPTION
This PR addresses issue #216.
Whether this code works for any of the packed bayer images is questionable, and should be tested. 
Computation of brightness for non-bayer images is still not supported.
