### PR TITLE
added missing ament_cmake_ros_dep to sync driver

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ROS_DISTRO: [galactic, humble, iron]
+        ROS_DISTRO: [humble, jazzy, rolling]
         ROS_REP: [testing, main]
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache" # directory for ccache (and how we enable ccache in industrial_ci)
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: ${{ env.CCACHE_DIR }}
           # This configuration will always create a new ccache cache starting off from the previous one (if any).

--- a/spinnaker_synchronized_camera_driver/package.xml
+++ b/spinnaker_synchronized_camera_driver/package.xml
@@ -8,7 +8,8 @@
   <license>Apache-2</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  
   <depend>spinnaker_camera_driver</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>


### PR DESCRIPTION
This PR fixes build errors on the ROS2 build farm. Not sure why this succeeded previously.