### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/spinnaker_synchronized_camera_driver/CMakeLists.txt
+++ b/spinnaker_synchronized_camera_driver/CMakeLists.txt
@@ -63,8 +63,7 @@ add_library(synchronized_camera_driver SHARED
   src/master_exposure_controller.cpp
   src/follower_exposure_controller.cpp)
 
-target_link_libraries(synchronized_camera_driver PUBLIC ${ROS_DEPENDENCIES})
-target_link_libraries(synchronized_camera_driver PUBLIC spinnaker_camera_driver::camera_driver PRIVATE yaml-cpp)
+target_link_libraries(synchronized_camera_driver PUBLIC rclcpp::rclcpp rclcpp_components::component rclcpp_components::component_manager spinnaker_camera_driver::camera_driver PRIVATE yaml-cpp)
 
 target_include_directories(synchronized_camera_driver
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/spinnaker_synchronized_camera_driver/CMakeLists.txt
+++ b/spinnaker_synchronized_camera_driver/CMakeLists.txt
@@ -63,7 +63,7 @@ add_library(synchronized_camera_driver SHARED
   src/master_exposure_controller.cpp
   src/follower_exposure_controller.cpp)
 
-ament_target_dependencies(synchronized_camera_driver PUBLIC ${ROS_DEPENDENCIES})
+target_link_libraries(synchronized_camera_driver PUBLIC ${ROS_DEPENDENCIES})
 target_link_libraries(synchronized_camera_driver PUBLIC spinnaker_camera_driver::camera_driver PRIVATE yaml-cpp)
 
 target_include_directories(synchronized_camera_driver


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
