### PR TITLE
fix deadlock bug on exit

### DIFF
--- a/spinnaker_camera_driver/cmake/download_spinnaker
+++ b/spinnaker_camera_driver/cmake/download_spinnaker
@@ -53,11 +53,11 @@ ARCH_LINUX_ARCH = {
 arch = sys.argv[1]
 destination_folder = sys.argv[2]
 os_code_name = sys.argv[3]
-spinnaker_version='4.2.0.46'
+spinnaker_version='4.2.0.88'
 
 linux_arch = ARCH_LINUX_ARCH[arch]
 os_version = OS_LIBRARY_VERSION[os_code_name]
-archive_url = f'https://pfrommer.us/Spinnaker/spinnaker-{spinnaker_version}-{linux_arch}-pkg-{os_version}.tar.gz'
+archive_url = f'https://eventvisionresearch.com/Spinnaker/spinnaker-{spinnaker_version}-{linux_arch}-{os_version}-pkg.tar.gz'
 print('archive url: ', archive_url)
 folder_name = f'spinnaker-{spinnaker_version}-{linux_arch}'
 

--- a/spinnaker_camera_driver/src/spinnaker_wrapper_impl.cpp
+++ b/spinnaker_camera_driver/src/spinnaker_wrapper_impl.cpp
@@ -555,7 +555,7 @@ void SpinnakerWrapperImpl::monitorStatus()
     const uint64_t t_now =
       chrono::duration_cast<chrono::nanoseconds>(chrono::system_clock::now().time_since_epoch())
         .count();
-    if (t_now - lastTime_ > acquisitionTimeout_) {
+    if (t_now - lastTime_ > acquisitionTimeout_ && keepRunning_) {
       Lock lock(cameraMutex_);
       if (camera_) {
         LOG_WARN("Acquisition timeout, restarting streaming!");


### PR DESCRIPTION
This PR fixes a deadlock where the synchronized driver wouldn't exit cleanly when acquisition timeouts were happening.